### PR TITLE
Add parallel option and function performance improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/Programs/functions/CC.scale.R
+++ b/Programs/functions/CC.scale.R
@@ -1,61 +1,85 @@
-CC.scale <- function(emission.fits.site,months,dates.sim,n.sites,perc.mu,perc.q,thshd.prcp,qq.month) {
+CC.scale <- function(emission.fits.site, 
+                     months, months.sim, n.sim, n.sites, 
+                     perc.mu, perc.q, thshd.prcp, qq.month) {
+  # this function takes fitted emission distributions to each site by month, and returns those parameters as
+  # an array of parameters with dimensions (n.sim, n.sites,n.parameters)
+  # it also enables a Clausius-Clapyeron scaling for the mean and the qqth quantile, and returns a similar
+  # array of parameters for emission distributions with that scaling
   
-  #this function takes fitted emission distributions to each site by month, and returns those parameters as 
-  #an array of parameters with dimensions (n.sim, n.sites,n.parameters) 
-  #it also enables a Clausius-Clapyeron scaling for the mean and the qqth quantile, and returns a similar
-  #array of parameters for emission distributions with that scaling
+  # Arguments:
+  # emission.fits.site = a list of length 2 (gamma and gpd fits), with each list containing an array of dimension (n.parameters x n.months x n.sites) that contains emission distribution parameters for each site and and month
+  # months = a vector of calendar months that define the season
+  # months.sim = month sequence for the simulation period
+  # n.sim = length of the simulation period
+  # n.sites = the number of individual sites
+  # perc.mu = the percentage by which to scale the mean
+  # perc.q = the percentage by which to scale the upper tail for CC scaling
+  # thshd.prcp = the threshold used to separate gamma from GPD
+  # qq.month = the frequency prcp under threshold by month and site
   
-  #Arguments:
-  #emission.fits.site = a list of length 2 (gamma and gpd fits), with each list containing an array of dimension (n.parameters x n.months x n.sites) that contains emission distribution parameters for each site and and month
-  #months = a vector of calendar months that define the season
-  #dates.sim = a vector of dates associated with the simulation period
-  #n.sites = the number of individual sites
-  #perc.mu = the percentage by which to scale the mean
-  #perc.q = the percentage by which to scale the upper tail for CC scaling
-  #thshd.prcp = the threshold used to separate gamma from GPD
-  #qq.month = the frequency prcp under threshold by month and site
-  
-  #month sequence for the simulation period
-  months.sim <- as.numeric(format(dates.sim,"%m"))
-  n.sim <- length(dates.sim)  #length of the simulation period
-  
-  #original fits  
+  # original fits
   emission.old1 <- emission.fits.site[[1]]
   
   # monthly-only #
-  #find the mean and upper quantile of the different distributions, and concatenate them with the parameters into a single array
-  
-  #q.max.prcp = the quantile for corresponding max prcp (month and site) under old gamma fits
+  # find the mean and upper quantile of the different distributions, and concatenate them with the parameters into a single array
+  # q.max.prcp = the quantile for corresponding max prcp (month and site) under old gamma fits
   q.max.prcp <- emission.fits.site[[3]]
   
-  q.old <- sapply(1:n.sites,function(x,z,m) {
-    qgamma(q.max.prcp[m,x],shape=z[1,m,x],rate=z[2,m,x])
-  }, z=emission.old1,m=months
-  )
-  mu.old <- apply(emission.old1,c(2,3),function(x) {x[1]/x[2]})
+  q.old <- sapply(1:n.sites, function(x, z, m) {
+    qgamma(q.max.prcp[m, x], shape = z[1, m, x], rate = z[2, m, x])
+  }, z = emission.old1, m = months)
+  mu.old <- apply(emission.old1, c(2, 3), function(x) {
+    x[1] / x[2]
+  })
   
-  #GPD means
-  gpd_mu <- thshd.prcp + apply(emission.fits.site[[2]],2,function(x) {x[1]/(1-x[2])})
-  gpd_mu.mat <- matrix(rep(gpd_mu,12),nrow=12,byrow=T)
-  perc.mu.gamma <- (perc.mu*qq.month*mu.old - (perc.q-perc.mu)*(1-qq.month)*gpd_mu.mat)/(qq.month*mu.old)
+  # GPD means
+  gpd_mu <- thshd.prcp + apply(emission.fits.site[[2]], 2, function(x) {
+    x[1] / (1 - x[2])
+  })
+  gpd_mu.mat <- matrix(rep(gpd_mu, 12), nrow = 12, byrow = T)
+  perc.mu.gamma <- (perc.mu * qq.month * mu.old - (perc.q - perc.mu) * (1 - qq.month) * gpd_mu.mat) / (qq.month * mu.old)
   
-  q.mu.old <- abind(q.old,mu.old,emission.old1,perc.mu.gamma,q.max.prcp,along=1)
+  q.mu.old <- abind(q.old, mu.old, emission.old1, perc.mu.gamma, q.max.prcp, along = 1)
   
-  #adjust distribution for new mean, upper quantile
-  emission.new1 <- apply(q.mu.old,c(2,3), function(x) {
+  # adjust distribution for new mean, upper quantile
+  emission.new1 <- apply(q.mu.old, c(2, 3), function(x) {
     start.par <- 1
     lowerb <- 0.0001
     upperb <- 10
-    opt <- optim(par=start.par,CC.scale.obj.fun,
-                 q.old=x[1],mu.old=x[2],
-                 param.old=x[3:4],
-                 perc.q=perc.q,perc.mu.gamma=x[5],
-                 q.max.prcp=x[6],
-                 method="L-BFGS-B",lower=lowerb,upper=upperb)
-    shape.new <- x[3]*x[5]*opt$par
-    rate.new <- x[4]*opt$par
-    return(c(shape.new,rate.new))
+    
+    # If optim fails, return the original parameters 
+    tryCatch(
+      {
+        opt <- optim(
+          par = start.par, CC.scale.obj.fun,
+          q.old = x[1], mu.old = x[2],
+          param.old = x[3:4],
+          perc.q = perc.q, perc.mu.gamma = x[5],
+          q.max.prcp = x[6],
+          method = "L-BFGS-B", lower = lowerb, upper = upperb
+        )
+        shape.new <- x[3] * x[5] * opt$par
+        rate.new <- x[4] * opt$par
+        c(shape.new, rate.new)
+      },
+      error = function(e) {
+        warning(sprintf(
+          "\n-Optimization failed: %s\nInput values: q.old = %f, mu.old = %f, param.old = (%f, %f), perc.q = %f, perc.mu = %f, perc.mu.gamma = %f\n",
+          e$message, x[1], x[2], x[3], x[4], perc.q, perc.mu, x[5]
+        ))
+        cat(sprintf(
+          "\n-Optimization failed: %s\nInput values: q.old = %f, mu.old = %f, param.old = (%f, %f), perc.q = %f, perc.mu = %f, perc.mu.gamma = %f\n",
+          e$message, x[1], x[2], x[3], x[4], perc.q, perc.mu, x[5]
+        ))
+        x[3:4]
+      }
+    )
+    
   })
-  return(list(emission.old1,emission.new1))
+  
+  return(list(emission.old1, emission.new1))
   
 }
+
+
+

--- a/Programs/functions/create.delimited.outputs.R
+++ b/Programs/functions/create.delimited.outputs.R
@@ -1,85 +1,109 @@
-
-create.delimited.outputs <- function(scenario = selected_scenario){
-  
+create.delimited.outputs <- function(scenario) {
   # this function creates output files #
-  #scenario = the row in ClimateChangeScenarios.csv for which to plot results
+  # scenario = the row in ClimateChangeScenarios.csv for which to plot results
+
+  # use fwrite from data.table package for faster write
+  p_load(data.table)
   
-  ##// weather data and synoptic dates ---##
-  #location of obs weather data
-  load(path.to.processed.data.meteohydro) #load in weather data
+  ## // weather data and synoptic dates ---##
+  # location of obs weather data
+  load(path.to.processed.data.meteohydro) # load in weather data
 
   # Sim. file
   cur.tc.max <- change.list$tc.max[scenario]
   cur.tc.min <- change.list$tc.min[scenario]
   cur.pccc <- change.list$pccc[scenario]
   cur.pmuc <- change.list$pmuc[scenario]
-  
-  ##// sim files ---##
+
+  ## // sim files ---##
   {
-    simulated.file.run.model.saved <- paste0(".tmax.",cur.tc.max,".tmin.",cur.tc.min,"_p.CC.scale.",cur.pccc,"_p.mu.scale.",cur.pmuc,"_num.year.",number.years.long,"_with.",num.iter)
-    
-    load(paste0(dir.to.sim.files,"/","prcp.site.sim",simulated.file.run.model.saved,".RData"))
+    simulated.file.run.model.saved <- paste0(".tmax.", cur.tc.max, 
+                                             ".tmin.", cur.tc.min, 
+                                             "_p.CC.scale.", cur.pccc, 
+                                             "_p.mu.scale.", cur.pmuc, 
+                                             "_num.year.", number.years.long, 
+                                             "_with.", num.iter)
+
+    load(paste0(dir.to.sim.files, "/", "prcp.site.sim", simulated.file.run.model.saved, ".RData"))
     prcp.site.data.sim <- prcp.site.sim[[1]] # because there was only one iteration
-    
-    load(paste0(dir.to.sim.files,"/","tmin.site.sim",simulated.file.run.model.saved,".RData"))
+
+    load(paste0(dir.to.sim.files, "/", "tmin.site.sim", simulated.file.run.model.saved, ".RData"))
     tmin.site.data.sim <- tmin.site.sim[[1]]
-    
-    load(paste0(dir.to.sim.files,"/","tmax.site.sim",simulated.file.run.model.saved,".RData"))
+
+    load(paste0(dir.to.sim.files, "/", "tmax.site.sim", simulated.file.run.model.saved, ".RData"))
     tmax.site.data.sim <- tmax.site.sim[[1]]
-    
-    #dates.sim
-    load(paste0(dir.to.sim.files,"/","dates.sim",simulated.file.run.model.saved,".RData"))
-    
-    months.sim <- as.numeric(format(dates.sim,"%m"))
-    years.sim <- as.numeric(format(dates.sim,"%Y"))
-    days.sim <- as.numeric(format(dates.sim,"%d"))
-    
+
+    # dates.sim
+    load(paste0(dir.to.sim.files, "/", "dates.sim", simulated.file.run.model.saved, ".RData"))
+
+    days.sim   <- day(dates.sim)
+    months.sim <- month(dates.sim)
+    years.sim  <- year(dates.sim)
   }
-  
+
   {
     # generating synthetic dates/years #
     a <- rle(years.sim)
     a.freq <- a$lengths
     a.val <- a$values
-    yr=1
+    yr <- 1
     yr.vec <- c()
-    for (k in 1:length(a.freq)){
-      yr.vec <- append(yr.vec,rep(yr,a.freq[k]))
-      yr <- yr+1
+    for (k in 1:length(a.freq)) {
+      yr.vec <- append(yr.vec, rep(yr, a.freq[k]))
+      yr <- yr + 1
     }
     long.years.vec <- yr.vec
-    long.months.vec <- as.numeric(months.sim)
+    long.months.vec <- months.sim
     total.num.yrs <- max(long.years.vec)
-    
   }
-  
-  
-  ##/ create a single long trace for each site
-  
-  long.dates.sim <- cbind(long.years.vec,long.months.vec,days.sim)
+
+
+  ## / create a single long trace for each site
+
+  long.dates.sim <- cbind(long.years.vec, long.months.vec, days.sim)
 
   start_time <- Sys.time()
+
+  # Create subfolder for each scenario
+  dir.to.output.files2 <- file.path(dir.to.output.files, paste0(
+    "tmax", cur.tc.max, "_",
+    "tmin", cur.tc.min, "_",
+    "pmuc", cur.pmuc, "_",
+    "pxtc", cur.pccc
+  ))
+  dir.create(file.path(dir.to.output.files2), showWarnings = FALSE, recursive = TRUE)
+  cat('\n\n - Saving new perturbed climate data to: ', dir.to.output.files2, "\n")
   
-  dir.create(file.path(dir.to.output.files), showWarnings = FALSE)
-  
-  for (k in 1:n.sites){
-    
+  for (k in 1:n.sites) {
     # sim output
     my.filename <- paste0(list.file.names[k])
-    dates.vec <- long.dates.sim
-    prcp.atemp <- cbind(prcp.site.data.sim[,k],
-                        tmax.site.data.sim[,k],
-                        tmin.site.data.sim[,k])
-    mat.to.save <- as.matrix(cbind(dates.vec,prcp.atemp)) # YEAR MONTH DAY PRCP MAX-TEMP MIN-TEMP
-    write.table(mat.to.save,file=paste0(dir.to.output.files,my.filename),
-                row.names = FALSE, col.names = FALSE, sep = " , ",quote = FALSE)
     
-    print(paste('site',k,'out of',n.sites,
-                '--',round(k/n.sites*100,2),"%"))
+    mat.to.save <- cbind(
+      long.dates.sim,
+      prcp.site.data.sim[, k],
+      tmax.site.data.sim[, k],
+      tmin.site.data.sim[, k]
+    )
+    mat.to.save <- as.data.table(mat.to.save)
+    
+    data.table::fwrite(
+      mat.to.save,
+      file = paste0(dir.to.output.files2, "/", my.filename),
+      sep = ",",
+      col.names = FALSE,
+      row.names = FALSE,
+      quote = FALSE
+    )
+    
+    # Print message every xxx files
+    if (k %% 5 == 0) {
+      message(sprintf("site %d out of %d -- %.2f%%", k, n.sites, k / n.sites * 100))
+    }
+    
   }
-  
-  end_time <- Sys.time(); run.time.saving.sim <- end_time - start_time
-  print(round(run.time.saving.sim,2))
-  
+
+  end_time <- Sys.time()
+  run.time.saving.sim <- end_time - start_time
+  print(round(run.time.saving.sim, 2))
   
 }

--- a/Programs/functions/create.figures.baselines.stacked.R
+++ b/Programs/functions/create.figures.baselines.stacked.R
@@ -1,4 +1,4 @@
-create.figures.baselines.stacked <- function(scenario = selected_scenario) {
+create.figures.baselines.stacked <- function(scenario) {
   # stacked version #
 
   # scenario = the row in ClimateChangeScenarios.csv for which to plot results
@@ -45,15 +45,25 @@ create.figures.baselines.stacked <- function(scenario = selected_scenario) {
   cur.pccc <- change.list$pccc[scenario]
   cur.pmuc <- change.list$pmuc[scenario]
 
-  cur.jitter <- to.jitter
-
+  cat("\nScenario: ", scenario, "|", 
+      "dTmax = ", cur.tc.max, "(deg C),",
+      "dTmin = ", cur.tc.min, "(deg C),",
+      "dPrec_avg (%) = ", 100*cur.pmuc, "(%),",
+      "dPrec_extreme/dT = ", 100*cur.pccc, "(% per deg)",
+      "\n\n")
+  
   ## // sim files ---##
   {
-    simulated.file.run.model.saved <- paste0(".tmax.", cur.tc.max, ".tmin.", cur.tc.min, "_p.CC.scale.", cur.pccc, "_p.mu.scale.", cur.pmuc, "_num.year.", number.years.long, "_with.", num.iter)
+    simulated.file.run.model.saved <- paste0(".tmax.", cur.tc.max, 
+                                             ".tmin.", cur.tc.min, 
+                                             "_p.CC.scale.", cur.pccc, 
+                                             "_p.mu.scale.", cur.pmuc, 
+                                             "_num.year.", number.years.long, 
+                                             "_with.", num.iter)
 
     prcp.site.sim_sfx <- "prcp.site.sim"
     load(paste0(dir.to.sim.files, "/", prcp.site.sim_sfx, simulated.file.run.model.saved, ".RData"))
-    prcp.site.data.sim <- prcp.site.sim[[1]] # becase there was only one iteration
+    prcp.site.data.sim <- prcp.site.sim[[1]] # because there was only one iteration
 
     prcp.site.sim_sfx <- "tmin.site.sim"
     load(paste0(dir.to.sim.files, "/", prcp.site.sim_sfx, simulated.file.run.model.saved, ".RData"))
@@ -83,15 +93,7 @@ create.figures.baselines.stacked <- function(scenario = selected_scenario) {
   {
     # generating synthetic dates/years #
     a <- rle(years.sim)
-    a.freq <- a$lengths
-    a.val <- a$values
-    yr <- 1
-    yr.vec <- c()
-    for (k in 1:length(a.freq)) {
-      yr.vec <- append(yr.vec, rep(yr, a.freq[k]))
-      yr <- yr + 1
-    }
-    long.years.vec <- yr.vec
+    long.years.vec <- rep(seq_along(a$lengths), times = a$lengths)
     long.months.vec <- months.sim
     total.num.yrs <- max(long.years.vec)
 
@@ -101,54 +103,40 @@ create.figures.baselines.stacked <- function(scenario = selected_scenario) {
     wateryears.sim <- (long.years.vec + 1) * (long.months.vec >= 10) + (long.years.vec) * (long.months.vec < 10)
 
     # water years precipitation total #
-    wy.data.obs <- apply(prcp.site.data, 2, function(x) {
-      aggregate(x, FUN = sum, by = list(wateryears.obs), na.rm = T)[, 2]
-    })
-    wy.data.obs <- apply(wy.data.obs, 2, function(x) {
-      return(x[2:(length(x) - 1)])
-    }) # drop first and last to only keep full water years
-
-    wy.data.sim <- apply(prcp.site.data.sim, 2, function(x) {
-      aggregate(x, FUN = sum, by = list(wateryears.sim), na.rm = T)[, 2]
-    })
-    wy.data.sim <- apply(wy.data.sim, 2, function(x) {
-      return(x[2:(length(x) - 1)])
-    }) # drop first and last to only keep full water years
+    wy.data.obs <- wy_avg_calculation(prcp.site.data, 
+                                      wateryears.obs,
+                                      "precip")
+    wy.data.sim <- wy_avg_calculation(prcp.site.data.sim, 
+                                      wateryears.sim,
+                                      "precip")
 
     # water years temperature average #
-    wy.tmean.data.obs <- apply(tmean.site.data, 2, function(x) {
-      aggregate(x, FUN = mean, by = list(wateryears.obs), na.rm = T)[, 2]
-    })
-    wy.tmean.data.obs <- apply(wy.tmean.data.obs, 2, function(x) {
-      return(x[2:(length(x) - 1)])
-    }) # drop first and last to only keep full water years
-
-    wy.tmean.data.sim <- apply(tmean.site.data.sim, 2, function(x) {
-      aggregate(x, FUN = mean, by = list(wateryears.sim), na.rm = T)[, 2]
-    })
-    wy.tmean.data.sim <- apply(wy.tmean.data.sim, 2, function(x) {
-      return(x[2:(length(x) - 1)])
-    }) # drop first and last to only keep full water years
+    wy.tmean.data.obs <- wy_avg_calculation(tmean.site.data, 
+                                            wateryears.obs,
+                                            "temperature")
+    wy.tmean.data.sim <- wy_avg_calculation(tmean.site.data.sim, 
+                                            wateryears.sim,
+                                            "temperature")
   }
 
 
   # average precipitation & temperature at-basin #
   {
     # average precipitation #
-    mean.prcp.site <- as.matrix(apply(prcp.site.data, 1, mean))
-    mean.prcp.site.sim <- as.matrix(apply(prcp.site.data.sim, 1, mean))
-
+    mean.prcp.site        <- row_mean_matrix(prcp.site.data)
+    mean.prcp.site.sim    <- row_mean_matrix(prcp.site.data.sim)
+    
     # average temperature #
-    mean.tmean.site <- as.matrix(apply(tmean.site.data, 1, mean))
-    mean.tmean.site.sim <- as.matrix(apply(tmean.site.data.sim, 1, mean))
+    mean.tmean.site       <- row_mean_matrix(tmean.site.data)
+    mean.tmean.site.sim   <- row_mean_matrix(tmean.site.data.sim)
 
     # average wy precipitation #
-    mean.wy.prcp.site <- as.matrix(apply(wy.data.obs, 1, mean))
-    mean.wy.prcp.site.sim <- as.matrix(apply(wy.data.sim, 1, mean))
-
+    mean.wy.prcp.site     <- row_mean_matrix(wy.data.obs)
+    mean.wy.prcp.site.sim <- row_mean_matrix(wy.data.sim)
+    
     # average wy temperature #
-    mean.wy.tmean.site <- as.matrix(apply(wy.tmean.data.obs, 1, mean))
-    mean.wy.tmean.site.sim <- as.matrix(apply(wy.tmean.data.sim, 1, mean))
+    mean.wy.tmean.site    <- row_mean_matrix(wy.tmean.data.obs)
+    mean.wy.tmean.site.sim<- row_mean_matrix(wy.tmean.data.sim)
   }
 
   #### Figure 1: ---------------------------------------------------------------
@@ -161,8 +149,8 @@ create.figures.baselines.stacked <- function(scenario = selected_scenario) {
     label12 <- "Obs [GPD]"
 
     file.name.fig <- paste0(
-      "lines_prcp.GEV.GPD.NEP_dur.maxima_wet.spells_", n.sites, ".files_s",
-      num.states, "_with_", num.iter, "_ens.png"
+      "Fig1_lines_prcp.GEV.GPD.NEP_dur.maxima_wet.spells_", n.sites, ".files_s",
+      num.states, "_with_", num.iter, "_Scenario_", scenario, "_ens.png"
     )
     fname.fig <- paste0(dir.to.figures, "/", file.name.fig)
     ww.mom <- 14
@@ -504,8 +492,8 @@ create.figures.baselines.stacked <- function(scenario = selected_scenario) {
   cat("\nScenario: ", scenario, "| 2) precipitation cdf, mean, standard variation (yearly, year-to-year)\n\n")
   {
     file.name.fig <- paste0(
-      "lines_prcp.mean_cdf_sd_", n.sites, ".files_s",
-      num.states, "_with_", num.iter, "_ens.png"
+      "Fig2_lines_prcp.mean_cdf_sd_", n.sites, ".files_s",
+      num.states, "_with_", num.iter, "_Scenario_", scenario, "_ens.png"
     )
     fname.fig <- paste0(dir.to.figures, "/", file.name.fig)
     ww.mom <- 14
@@ -538,12 +526,15 @@ create.figures.baselines.stacked <- function(scenario = selected_scenario) {
     EP.hat <- (1:length(y.hat)) / (length(y.hat) + 1)
     y <- annual.prcp.sim
     EP <- (1:length(y)) / (length(y) + 1)
+    ylim_prcp <- c(0.9*min(boot.05, annual.prcp.sim), 
+                   1.1*max(boot.95, annual.prcp.sim))
     plot(EP.hat, sort(y.hat),
-      log = "y", type = "l", frame = F,
-      col = "red", lwd = 5, xlab = "Exceedance Probability", ylab = "Precipitation [WY]",
-      cex.axis = 2, cex.main = 4, cex.lab = 2, font.main = 1
+         log = "y", type = "l", frame = F,
+         ylim = ylim_prcp,
+         col = "red", lwd = 5, xlab = "Exceedance Probability", ylab = "Precipitation [WY]",
+         cex.axis = 2, cex.main = 4, cex.lab = 2, font.main = 1
     )
-    lines(EP, sort(y), lty = 1, col = "gray50", lwd = 6)
+    lines(EP, sort(y), lty = 2, col = "gray50", lwd = 5)
     polygon(
       x = c(EP.hat, rev(EP.hat)), y = c(boot.05, rev(boot.95)),
       col = alpha("red", 0.15), border = NA
@@ -596,15 +587,12 @@ create.figures.baselines.stacked <- function(scenario = selected_scenario) {
     ## -- whiskers of long trace metrics -- ##
     #--------------------------------------- #
     labs.metrics <- c("mean", "stdev")
-    lst.annual.obs <- lst.annual.sim <- vector("list", length(labs.metrics))
-    lst.annual.obs[[1]] <- aggregate(prcp.site.data, FUN = mean, by = list(wateryears.obs))[, -1]
-    lst.annual.sim[[1]] <- aggregate(prcp.site.data.sim, FUN = mean, by = list(wateryears.sim))[, -1]
-    lst.annual.obs[[2]] <- aggregate(prcp.site.data, FUN = sd, by = list(wateryears.obs))[, -1]
-    lst.annual.sim[[2]] <- aggregate(prcp.site.data.sim, FUN = sd, by = list(wateryears.sim))[, -1]
-
+    lst.annual.prcp.obs <- annual_metrics(prcp.site.data, wateryears.obs, labs.metrics)
+    lst.annual.prcp.sim <- annual_metrics(prcp.site.data.sim, wateryears.sim, labs.metrics)
+    
     for (k in 1:length(labs.metrics)) {
-      annual.obs <- lst.annual.obs[[k]]
-      annual.sim <- lst.annual.sim[[k]]
+      annual.obs <- lst.annual.prcp.obs[[k]]
+      annual.sim <- lst.annual.prcp.sim[[k]]
       my.sim.y <- annual.sim
       my.obs.y <- annual.obs
 
@@ -658,8 +646,8 @@ create.figures.baselines.stacked <- function(scenario = selected_scenario) {
     # label2 <- 'Sim (WGEN: baseline)'
 
     file.name.fig <- paste0(
-      "lines_prcp.cumulative_seasonality_", n.sites, ".files_s",
-      num.states, "_with_", num.iter, "_ens.png"
+      "Fig3_lines_prcp.cumulative_seasonality_", n.sites, ".files_s",
+      num.states, "_with_", num.iter, "_Scenario_", scenario, "_ens.png"
     )
     fname.fig <- paste0(dir.to.figures, "/", file.name.fig)
     ww.mom <- 15
@@ -858,8 +846,8 @@ create.figures.baselines.stacked <- function(scenario = selected_scenario) {
   cat("\nScenario: ", scenario, "| 4) temperature cdf, mean, standard variation (yearly, year-to-year)\n\n")
   {
     file.name.fig <- paste0(
-      "lines_tmean_mean_cdf_sd_", n.sites, ".files_s",
-      num.states, "_with_", num.iter, "_ens.png"
+      "Fig4_lines_tmean_mean_cdf_sd_", n.sites, ".files_s",
+      num.states, "_with_", num.iter, "_Scenario_", scenario, "_ens.png"
     )
     fname.fig <- paste0(dir.to.figures, "/", file.name.fig)
     ww.mom <- 14
@@ -892,13 +880,18 @@ create.figures.baselines.stacked <- function(scenario = selected_scenario) {
     EP.hat <- (1:length(y.hat)) / (length(y.hat) + 1)
     y <- annual.tmean.sim
     EP <- (1:length(y)) / (length(y) + 1)
-    plot(EP.hat, sort(y.hat),
-      log = "y", type = "l", frame = F,
-      col = "red", lwd = 5,
-      xlab = "Exceedance Probability", ylab = "Temperature [WY]",
-      cex.axis = 2, cex.main = 4, cex.lab = 2, font.main = 1
+    ylim_tmean <- c(
+      min(0.9*c(boot.05, annual.tmean.sim)),
+      max(1.1*c(boot.95, annual.tmean.sim))
     )
-    lines(EP, sort(y), lty = 1, col = "gray50", lwd = 6)
+    plot(EP.hat, sort(y.hat),
+         log = "y", type = "l", frame = F,
+         ylim = ylim_tmean,
+         col = "red", lwd = 5,
+         xlab = "Exceedance Probability", ylab = "Temperature [WY]",
+         cex.axis = 2, cex.main = 4, cex.lab = 2, font.main = 1
+    )
+    lines(EP, sort(y), lty = 2, col = "gray60", lwd = 5)
     polygon(
       x = c(EP.hat, rev(EP.hat)), y = c(boot.05, rev(boot.95)),
       col = alpha("red", 0.15), border = NA
@@ -949,17 +942,12 @@ create.figures.baselines.stacked <- function(scenario = selected_scenario) {
     #--------------------------------------- #
     ## -- whiskers of long trace metrics -- ##
     #--------------------------------------- #
-    lst.annual.obs <- lst.annual.sim <- vector("list", length(labs.metrics))
-    lst.annual.obs[[1]] <- aggregate(tmean.site.data, FUN = mean, by = list(wateryears.obs))[, -1]
-    lst.annual.sim[[1]] <- aggregate(tmean.site.data.sim, FUN = mean, by = list(wateryears.sim))[, -1]
-    lst.annual.obs[[2]] <- aggregate(tmean.site.data, FUN = sd, by = list(wateryears.obs))[, -1]
-    lst.annual.sim[[2]] <- aggregate(tmean.site.data.sim, FUN = sd, by = list(wateryears.sim))[, -1]
-
-    # labs.metrics <- c("mean", "stdev")
-
+    lst.annual.tmean.obs <- annual_metrics(tmean.site.data, wateryears.obs, labs.metrics)
+    lst.annual.tmean.sim <- annual_metrics(tmean.site.data.sim, wateryears.sim, labs.metrics)
+    
     for (k in 1:length(labs.metrics)) {
-      annual.obs <- lst.annual.obs[[k]]
-      annual.sim <- lst.annual.sim[[k]]
+      annual.obs <- lst.annual.tmean.obs[[k]]
+      annual.sim <- lst.annual.tmean.sim[[k]]
       my.sim.y <- annual.sim
       my.obs.y <- annual.obs
 
@@ -1232,8 +1220,8 @@ create.figures.baselines.stacked <- function(scenario = selected_scenario) {
     )
 
     file.name.fig <- paste0(
-      "scatters_tmax_tmin_heat.cold.specific_", n.sites, ".files_s",
-      num.states, "_with_", num.iter, "_ens.png"
+      "Fig5_scatters_tmax_tmin_heat.cold.specific_", n.sites, ".files_s",
+      num.states, "_with_", num.iter, "_Scenario_", scenario, "_ens.png"
     )
     fname.fig <- paste0(dir.to.figures, "/", file.name.fig)
     ww.mom <- 18
@@ -1282,8 +1270,8 @@ create.figures.baselines.stacked <- function(scenario = selected_scenario) {
   cat("\nScenario: ", scenario, "| 6) precipitation minima, dry-spells, drought stats\n\n")
   {
     file.name.fig <- paste0(
-      "hist_prcp.n.year.droughts_minima_dry.spells_", n.sites, ".files_s",
-      num.states, "_with_", num.iter, "_ens.png"
+      "Fig6_hist_prcp.n.year.droughts_minima_dry.spells_", n.sites, ".files_s",
+      num.states, "_with_", num.iter, "_Scenario_", scenario, "_ens.png"
     )
     fname.fig <- paste0(dir.to.figures, "/", file.name.fig)
     ww.mom <- 26
@@ -1525,4 +1513,103 @@ create.figures.baselines.stacked <- function(scenario = selected_scenario) {
 
   # The end #
 }
+
+
+
+
+wy_avg_calculation <- function(input_data, 
+                               daily_wy_vect,
+                               var_name) {
+  
+  p_load(data.table)
+  
+  dt <- as.data.table(input_data)
+  
+  # Add water year column
+  dt[, wateryear := daily_wy_vect]
+  
+  # Melt the data.table to long format 
+  dt_long <- melt(dt, 
+                  id.vars = "wateryear", 
+                  variable.name = "site", 
+                  value.name = var_name)
+  
+  if (grepl("precip", var_name)) {
+    
+    # Sum precipitation by water year and site
+    wy_data <- dt_long[, .(total_precip = sum(get(var_name), na.rm = TRUE)), 
+                       by = .(wateryear, site)]
+    
+    # Drop first and last water years
+    valid_years <- sort(unique(wy_data$wateryear))
+    wy_data <- wy_data[wateryear %in% valid_years[2:(length(valid_years) - 1)]]
+    
+    # Convert back to wide format
+    wy_data_wide <- dcast(wy_data, wateryear ~ site, value.var = "total_precip")
+    
+    # Remove the wateryear column and convert to matrix
+    wy_data_matrix <- as.matrix(wy_data_wide[, -1])
+    # str(wy_data_matrix)
+    
+  } else {
+    
+    # Average temperature by water year and site
+    wy_data <- dt_long[, .(avg_temperature = mean(get(var_name), na.rm = TRUE)), 
+                       by = .(wateryear, site)]
+    
+    # Drop first and last water years
+    valid_years <- sort(unique(wy_data$wateryear))
+    wy_data <- wy_data[wateryear %in% valid_years[2:(length(valid_years) - 1)]]
+    wy_data
+    
+    wy_data_wide <- dcast(wy_data, wateryear ~ site, value.var = "avg_temperature")
+    wy_data_matrix <- as.matrix(wy_data_wide[, -1])
+    
+  }
+  
+  return(wy_data_matrix)
+  
+}
+
+
+
+row_mean_matrix <- function(input_data) {
+  
+  p_load(data.table)
+  
+  dt <- as.data.table(input_data)
+  # Compute row-wise mean, ignoring NA
+  mean_matrix <- as.matrix(rowMeans(dt, na.rm = TRUE))
+  
+  return(mean_matrix)
+}
+
+
+
+annual_metrics <- function(input_data, wateryears, metrics = c("mean", "stdev")) {
+  
+  p_load(data.table)
+  
+  dt <- as.data.table(input_data)
+  dt[, wateryear := wateryears]
+  
+  results <- vector("list", length(metrics))
+  names(results) <- metrics
+  
+  # Loop through each metric
+  for (i in seq_along(metrics)) {
+    metric <- metrics[i]
+    
+    # Apply metric by wateryear
+    results[[i]] <- dt[, lapply(.SD, function(x) {
+      if (metric == "mean") mean(x, na.rm = TRUE)
+      else if (metric == "stdev") sd(x, na.rm = TRUE)
+      else stop("Unsupported metric")
+    }), by = wateryear][, -1] |> as.data.frame()
+  }
+  
+  return(results)
+}
+
+
 

--- a/Programs/functions/create.figures.baselines.stacked.R
+++ b/Programs/functions/create.figures.baselines.stacked.R
@@ -1,9 +1,8 @@
-
-create.figures.baselines.stacked <- function(scenario=selected_scenario){
+create.figures.baselines.stacked <- function(scenario = selected_scenario) {
   # stacked version #
-  
-  #scenario = the row in ClimateChangeScenarios.csv for which to plot results
-  
+
+  # scenario = the row in ClimateChangeScenarios.csv for which to plot results
+
   # ------------------------------------------------------------------------------- #
   # ------------------------------------------------------------------------------- #
   # A set of 6 figures stacked to show diagnostics for WGEN: precipitation and temperature #
@@ -14,167 +13,187 @@ create.figures.baselines.stacked <- function(scenario=selected_scenario){
   # - Temperature: averages, variability, heat waves, heat stress, cold waves, cold stress
   # - at-basin: statistics that have been calculated based on a basin average of precipitation and temperature data (i.e., avg across sites)
   # - at-site: statistics that are shown for each site individually
-  
-  #location of obs weather data
-  load(path.to.processed.data.meteohydro) #load in weather data
 
-  #preset labels for figures below
-  identical.dates.idx <- dates.weather%in%dates.synoptics
+  # location of obs weather data
+  load(path.to.processed.data.meteohydro) # load in weather data
+
+  p_load(data.table)
+  
+  # preset labels for figures below
+  identical.dates.idx <- dates.weather %in% dates.synoptics
   dates.weather <- dates.weather[identical.dates.idx]
-  years.weather <- as.numeric(format(dates.weather,'%Y'))
-  months.weather <- as.numeric(format(dates.weather,'%m'))
-  
-  label1 = paste0('Obs [',format(as.Date(range(dates.weather)[1]),'%Y'),
-                  '-',format(as.Date(range(dates.weather)[2]),'%Y'),']')
-  label2 = 'Sim (WGEN: baseline)'
-  
-  ##// cut obs weather data to synoptic dates for fair comparison ---##
-  prcp.site.data <- prcp.site[identical.dates.idx,]
-  tmin.site.data <- tmin.site[identical.dates.idx,]
-  tmax.site.data <- tmax.site[identical.dates.idx,]
-  tmean.site.data <- (tmin.site.data+tmax.site.data)/2
-  
+  years.weather <- year(dates.weather)
+  months.weather <- month(dates.weather)
+
+  label1 <- paste0(
+    "Obs [", format(as.Date(range(dates.weather)[1]), "%Y"),
+    "-", format(as.Date(range(dates.weather)[2]), "%Y"), "]"
+  )
+  label2 <- "Sim (WGEN: baseline)"
+
+  ## // cut obs weather data to synoptic dates for fair comparison ---##
+  prcp.site.data <- prcp.site[identical.dates.idx, ]
+  tmin.site.data <- tmin.site[identical.dates.idx, ]
+  tmax.site.data <- tmax.site[identical.dates.idx, ]
+  tmean.site.data <- (tmin.site.data + tmax.site.data) / 2
+
   n.sites <- dim(prcp.site)[2] # Number of locations
-  
-  #select the scenario for plotting
+
+  # select the scenario for plotting
   cur.tc.max <- change.list$tc.max[scenario]
   cur.tc.min <- change.list$tc.min[scenario]
   cur.pccc <- change.list$pccc[scenario]
   cur.pmuc <- change.list$pmuc[scenario]
 
   cur.jitter <- to.jitter
-  
-  ##// sim files ---##
+
+  ## // sim files ---##
   {
-    simulated.file.run.model.saved <- paste0(".tmax.",cur.tc.max,".tmin.",cur.tc.min,"_p.CC.scale.",cur.pccc,"_p.mu.scale.",cur.pmuc,"_num.year.",number.years.long,"_with.",num.iter)
+    simulated.file.run.model.saved <- paste0(".tmax.", cur.tc.max, ".tmin.", cur.tc.min, "_p.CC.scale.", cur.pccc, "_p.mu.scale.", cur.pmuc, "_num.year.", number.years.long, "_with.", num.iter)
 
     prcp.site.sim_sfx <- "prcp.site.sim"
-    load(paste0(dir.to.sim.files,"/",prcp.site.sim_sfx,simulated.file.run.model.saved,".RData"))
+    load(paste0(dir.to.sim.files, "/", prcp.site.sim_sfx, simulated.file.run.model.saved, ".RData"))
     prcp.site.data.sim <- prcp.site.sim[[1]] # becase there was only one iteration
-    
+
     prcp.site.sim_sfx <- "tmin.site.sim"
-    load(paste0(dir.to.sim.files,"/",prcp.site.sim_sfx,simulated.file.run.model.saved,".RData"))
+    load(paste0(dir.to.sim.files, "/", prcp.site.sim_sfx, simulated.file.run.model.saved, ".RData"))
     tmin.site.data.sim <- tmin.site.sim[[1]]
-    
+
     prcp.site.sim_sfx <- "tmax.site.sim"
-    load(paste0(dir.to.sim.files,"/",prcp.site.sim_sfx,simulated.file.run.model.saved,".RData"))
+    load(paste0(dir.to.sim.files, "/", prcp.site.sim_sfx, simulated.file.run.model.saved, ".RData"))
     tmax.site.data.sim <- tmax.site.sim[[1]]
-    
-    tmean.site.data.sim <- (tmax.site.data.sim+tmin.site.data.sim)/2
-    
+
+    tmean.site.data.sim <- (tmax.site.data.sim + tmin.site.data.sim) / 2
+
     prcp.site.sim_sfx <- "dates.sim"
-    load(paste0(dir.to.sim.files,"/",prcp.site.sim_sfx,simulated.file.run.model.saved,".RData"))
-    #dates.sim
-    
-    months.sim <- as.numeric(format(dates.sim,"%m"))
-    years.sim <- as.numeric(format(dates.sim,"%Y"))
+    load(paste0(dir.to.sim.files, "/", prcp.site.sim_sfx, simulated.file.run.model.saved, ".RData"))
+
+    months.sim <- month(dates.sim)
+    years.sim  <- year(dates.sim)
   }
   
-  
+  # create subfolder for each scenario
+  dir.to.figures <- file.path("Figures", paste0("tmax.", cur.tc.max, 
+                                                "_tmin.", cur.tc.min, 
+                                                "_p.CC.scale.", cur.pccc, 
+                                                "_p.mu.scale.", cur.pmuc))
+  dir.create(dir.to.figures, showWarnings = FALSE, recursive = TRUE)
+
   # water years dates/values #
   {
     # generating synthetic dates/years #
     a <- rle(years.sim)
     a.freq <- a$lengths
     a.val <- a$values
-    yr=1
+    yr <- 1
     yr.vec <- c()
-    for (k in 1:length(a.freq)){
-      yr.vec <- append(yr.vec,rep(yr,a.freq[k]))
-      yr <- yr+1
+    for (k in 1:length(a.freq)) {
+      yr.vec <- append(yr.vec, rep(yr, a.freq[k]))
+      yr <- yr + 1
     }
     long.years.vec <- yr.vec
-    long.months.vec <- as.numeric(months.sim)
+    long.months.vec <- months.sim
     total.num.yrs <- max(long.years.vec)
-    
+
     # water years dates #
-    wateryears.weather <- (years.weather+1)*(months.weather>=10) + (years.weather)*(months.weather<10)
+    wateryears.weather <- (years.weather + 1) * (months.weather >= 10) + (years.weather) * (months.weather < 10)
     wateryears.obs <- wateryears.weather
-    wateryears.sim <- (long.years.vec+1)*(long.months.vec>=10) + (long.years.vec)*(long.months.vec<10)
-    
+    wateryears.sim <- (long.years.vec + 1) * (long.months.vec >= 10) + (long.years.vec) * (long.months.vec < 10)
+
     # water years precipitation total #
-    wy.data.obs <- apply(prcp.site.data,2,function(x){
-      aggregate(x,FUN=sum,by=list(wateryears.obs),na.rm=T)[,2]})
-    wy.data.obs <- apply(wy.data.obs,2,function(x){
-      return(x[2:(length(x)-1)])})#drop first and last to only keep full water years
-    
-    wy.data.sim <- apply(prcp.site.data.sim,2,function(x){
-      aggregate(x,FUN=sum,by=list(wateryears.sim),na.rm=T)[,2]})
-    wy.data.sim <- apply(wy.data.sim,2,function(x){
-      return(x[2:(length(x)-1)])})#drop first and last to only keep full water years
-    
+    wy.data.obs <- apply(prcp.site.data, 2, function(x) {
+      aggregate(x, FUN = sum, by = list(wateryears.obs), na.rm = T)[, 2]
+    })
+    wy.data.obs <- apply(wy.data.obs, 2, function(x) {
+      return(x[2:(length(x) - 1)])
+    }) # drop first and last to only keep full water years
+
+    wy.data.sim <- apply(prcp.site.data.sim, 2, function(x) {
+      aggregate(x, FUN = sum, by = list(wateryears.sim), na.rm = T)[, 2]
+    })
+    wy.data.sim <- apply(wy.data.sim, 2, function(x) {
+      return(x[2:(length(x) - 1)])
+    }) # drop first and last to only keep full water years
+
     # water years temperature average #
-    wy.tmean.data.obs <- apply(tmean.site.data,2,function(x){
-      aggregate(x,FUN=mean,by=list(wateryears.obs),na.rm=T)[,2]})
-    wy.tmean.data.obs <- apply(wy.tmean.data.obs,2,function(x){
-      return(x[2:(length(x)-1)])})#drop first and last to only keep full water years
-    
-    wy.tmean.data.sim <- apply(tmean.site.data.sim,2,function(x){
-      aggregate(x,FUN=mean,by=list(wateryears.sim),na.rm=T)[,2]})
-    wy.tmean.data.sim <- apply(wy.tmean.data.sim,2,function(x){
-      return(x[2:(length(x)-1)])})#drop first and last to only keep full water years
+    wy.tmean.data.obs <- apply(tmean.site.data, 2, function(x) {
+      aggregate(x, FUN = mean, by = list(wateryears.obs), na.rm = T)[, 2]
+    })
+    wy.tmean.data.obs <- apply(wy.tmean.data.obs, 2, function(x) {
+      return(x[2:(length(x) - 1)])
+    }) # drop first and last to only keep full water years
+
+    wy.tmean.data.sim <- apply(tmean.site.data.sim, 2, function(x) {
+      aggregate(x, FUN = mean, by = list(wateryears.sim), na.rm = T)[, 2]
+    })
+    wy.tmean.data.sim <- apply(wy.tmean.data.sim, 2, function(x) {
+      return(x[2:(length(x) - 1)])
+    }) # drop first and last to only keep full water years
   }
-  
-  
+
+
   # average precipitation & temperature at-basin #
   {
     # average precipitation #
-    mean.prcp.site <- as.matrix(apply(prcp.site.data,1,mean))
-    mean.prcp.site.sim <- as.matrix(apply(prcp.site.data.sim,1,mean))
-    
+    mean.prcp.site <- as.matrix(apply(prcp.site.data, 1, mean))
+    mean.prcp.site.sim <- as.matrix(apply(prcp.site.data.sim, 1, mean))
+
     # average temperature #
-    mean.tmean.site <- as.matrix(apply(tmean.site.data,1,mean))
-    mean.tmean.site.sim <- as.matrix(apply(tmean.site.data.sim,1,mean))
-    
+    mean.tmean.site <- as.matrix(apply(tmean.site.data, 1, mean))
+    mean.tmean.site.sim <- as.matrix(apply(tmean.site.data.sim, 1, mean))
+
     # average wy precipitation #
-    mean.wy.prcp.site <- as.matrix(apply(wy.data.obs,1,mean))
-    mean.wy.prcp.site.sim <- as.matrix(apply(wy.data.sim,1,mean))
-    
+    mean.wy.prcp.site <- as.matrix(apply(wy.data.obs, 1, mean))
+    mean.wy.prcp.site.sim <- as.matrix(apply(wy.data.sim, 1, mean))
+
     # average wy temperature #
-    mean.wy.tmean.site <- as.matrix(apply(wy.tmean.data.obs,1,mean))
-    mean.wy.tmean.site.sim <- as.matrix(apply(wy.tmean.data.sim,1,mean))
-    
+    mean.wy.tmean.site <- as.matrix(apply(wy.tmean.data.obs, 1, mean))
+    mean.wy.tmean.site.sim <- as.matrix(apply(wy.tmean.data.sim, 1, mean))
   }
-  
-  # Figure 1:
+
+  #### Figure 1: ---------------------------------------------------------------
   # 1) precipitation extremes, wet-spells, flood stats
+  cat("\nScenario: ", scenario, "| 1) precipitation extremes, wet-spells, flood stats\n\n")
   {
     # label1 <- 'Obs [1950-2013]' # change wrt your observed dates/meteohydro
     # label2 <- 'Sim (WGEN: baseline)'
-    label11 <- 'Obs [GEV]'
-    label12 <- 'Obs [GPD]'
-    
-    file.name.fig <- paste0("lines_prcp.GEV.GPD.NEP_dur.maxima_wet.spells_",n.sites,".files_s",
-                            num.states,"_with_",num.iter,"_ens.png")
-    fname.fig <- paste0("./Figures/",file.name.fig)
-    ww.mom <- 14; hh.mom <- 14
-    png(fname.fig,width=ww.mom,height=hh.mom,units="in",res=300)
-    par(mfrow=c(2,2),mai=c(1,1,1,0.5))
-    
+    label11 <- "Obs [GEV]"
+    label12 <- "Obs [GPD]"
+
+    file.name.fig <- paste0(
+      "lines_prcp.GEV.GPD.NEP_dur.maxima_wet.spells_", n.sites, ".files_s",
+      num.states, "_with_", num.iter, "_ens.png"
+    )
+    fname.fig <- paste0(dir.to.figures, "/", file.name.fig)
+    ww.mom <- 14
+    hh.mom <- 14
+    png(fname.fig, width = ww.mom, height = hh.mom, units = "in", res = 300)
+    par(mfrow = c(2, 2), mai = c(1, 1, 1, 0.5))
+
     # (a)
     #----------------------------------------- #
     ## -- GPD threshold -- ##
     #----------------------------------------- #
     my.u.cluster <- 0.99
     num.per.block <- 365
-    #my.ret.per <- c(2,5,10,20,50,100,500,1000)
-    my.ret.per <- seq(1.001,10000)
+    # my.ret.per <- c(2,5,10,20,50,100,500,1000)
+    my.ret.per <- seq(1.001, 10000)
     # obs annual max
     PRCP.input <- mean.prcp.site
     years.input <- wateryears.weather
-    site.data.info <- data.frame(cbind(PRCP.input,years.input))
-    colnames(site.data.info) <- c("PRCP","YEARS")
+    site.data.info <- data.frame(cbind(PRCP.input, years.input))
+    colnames(site.data.info) <- c("PRCP", "YEARS")
     site.data.info$time <- 1:nrow(site.data.info)
-    my.u.threshold <- quantile(site.data.info$PRCP[site.data.info$PRCP>0],probs=my.u.cluster)
+    my.u.threshold <- quantile(site.data.info$PRCP[site.data.info$PRCP > 0], probs = my.u.cluster)
     site.data.info$lambda <- my.u.threshold
-    idx.pot <- which(site.data.info$PRCP>my.u.threshold,arr.ind = T)#extra
-    years.p.max <- site.data.info$YEARS[idx.pot]#extra
-    lambda.occurrence_counts <- mean(table(years.p.max))#extra
-    
-    #PDS is the data frame with annual maxima
+    idx.pot <- which(site.data.info$PRCP > my.u.threshold, arr.ind = T) # extra
+    years.p.max <- site.data.info$YEARS[idx.pot] # extra
+    lambda.occurrence_counts <- mean(table(years.p.max)) # extra
+
+    # PDS is the data frame with annual maxima
     PDS <- site.data.info
     my.thre <- unique(PDS$lambda)
-    #fit competing stationary models based on PRCP
+    # fit competing stationary models based on PRCP
     # static.gpd <- ismev::gpd.fit(PDS$PRCP,
     #                              show=TRUE,threshold=my.thre,
     #                              npy=num.per.block,
@@ -182,18 +201,19 @@ create.figures.baselines.stacked <- function(scenario=selected_scenario){
     # gpd.diag(static.gpd)
     # mrl.plot(PDS$PRCP,umin = min(PDS$PRCP), umax = max(PDS$PRCP)- 0.1,
     #          conf = 0.95, nint = 100)
-    static.gpd <- fevd(PDS$PRCP,threshold = my.thre,type='GP')
-    my.rls <- return.level(static.gpd,do.ci=TRUE,
-                           return.period = my.ret.per)
+    static.gpd <- fevd(PDS$PRCP, threshold = my.thre, type = "GP")
+    my.rls <- return.level(static.gpd,
+      do.ci = TRUE,
+      return.period = my.ret.per
+    )
     my.rl.vals <- as.matrix(my.rls)
     rownames(my.rl.vals) <- NULL
-    
-    
+
+
     #----------------------------------------- #
     ## -- GEV, NEP -- ##
     #----------------------------------------- #
-    my.gev.rl <- function (a, mat, dat, ymax, site.num) 
-    {
+    my.gev.rl <- function(a, mat, dat, ymax, site.num) {
       require(ismev)
       eps <- 1e-06
       a1 <- a
@@ -202,1114 +222,1307 @@ create.figures.baselines.stacked <- function(scenario=selected_scenario){
       a1[1] <- a[1] + eps
       a2[2] <- a[2] + eps
       a3[3] <- a[3] + eps
-      f <- c(seq(0.01, 0.09, by = 0.01), 0.1, 0.2, 0.3, 0.4, 0.5, 
-             0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 0.995, 0.999, 0.9999, 0.99999)
+      f <- c(
+        seq(0.01, 0.09, by = 0.01), 0.1, 0.2, 0.3, 0.4, 0.5,
+        0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 0.995, 0.999, 0.9999, 0.99999
+      )
       q <- gevq(a, 1 - f)
       d <- t(gev.rl.gradient(a = a, p = 1 - f))
       v <- apply(d, 1, q.form, m = mat)
-      
-      #ymax <- max(dat, q+ 1.96 * sqrt(v))
+
+      # ymax <- max(dat, q+ 1.96 * sqrt(v))
       # ymax <- max(dat, ymax, q+ 1.96 * sqrt(v))
       # ymin <- min(dat, q- 1.96 * sqrt(v))
-      ymax <- max(dat, ymax, q+sqrt(v))
-      ymin <- min(dat, q-sqrt(v))
-      plot(-1/log(f), q, log = "x", type = "n", xlim = c(0.1, 5000), panel.first=grid(equilogs=TRUE,lty=1,col="gray80",lwd=0.5),
-           ylim = c(ymin, ymax), xlab = "Return Period [year]",font.main = 1, 
-           ylab = "Precipitation [return level]",xaxt = 'n',
-           cex=2,main='',
-           cex.axis=1.75,cex.lab=1.5,cex.main=2, frame=FALSE)
+      ymax <- max(dat, ymax, q + sqrt(v))
+      ymin <- min(dat, q - sqrt(v))
+      plot(-1 / log(f), q,
+        log = "x", type = "n", xlim = c(0.1, 5000), panel.first = grid(equilogs = TRUE, lty = 1, col = "gray80", lwd = 0.5),
+        ylim = c(ymin, ymax), xlab = "Return Period [year]", font.main = 1,
+        ylab = "Precipitation [return level]", xaxt = "n",
+        cex = 2, main = "",
+        cex.axis = 1.75, cex.lab = 1.5, cex.main = 2, frame = FALSE
+      )
       # newx <- -1/log(f)
       # newy <- q
       # polygon(c(rev(newx), newx), c(rev(newy),newy), density=20, col = rgb(0,1,0,0.3), border = NA)
-      
-      lines(-1/log(f), q, col='red',lty=1, lwd=1.5)
-      lines(-1/log(f), q + 1.96 * sqrt(v), col = alpha("red",.4), lty=2, lwd=1)
-      lines(-1/log(f), q - 1.96 * sqrt(v), col = alpha("red",.4), lty=2, lwd=1)
-      points(-1/log((1:length(dat))/(length(dat) + 1)), sort(dat),col='red', pch=4)
+
+      lines(-1 / log(f), q, col = "red", lty = 1, lwd = 1.5)
+      lines(-1 / log(f), q + 1.96 * sqrt(v), col = alpha("red", .4), lty = 2, lwd = 1)
+      lines(-1 / log(f), q - 1.96 * sqrt(v), col = alpha("red", .4), lty = 2, lwd = 1)
+      points(-1 / log((1:length(dat)) / (length(dat) + 1)), sort(dat), col = "red", pch = 4)
     }
-    
-    fct.prcp.sim.annmax <- function(prcp,my.years,my.range=NULL,mc.cores=1){
+
+    fct.prcp.sim.annmax <- function(prcp, my.years, my.range = NULL, mc.cores = 1) {
       uniq.years <- unique(my.years)
       d <- length(prcp)
       n.sites <- dim(prcp[[1]])[2]
-      if(is.null(my.range)) {my.range <- 1:dim(prcp[[1]])[1]}
-      stat.rp.rl.list <- mclapply(X=1:d,mc.preschedule=TRUE,mc.cores=mc.cores,FUN=function(i){  
-        cur.prcp <- as.matrix(prcp[[i]][my.range,])
-        if (sum(is.infinite(cur.prcp))>0){
-          idx.dummy <- which(is.infinite(cur.prcp),arr.ind = T)
-          cur.prcp[idx.dummy[,1],idx.dummy[,2]] <- NA} # checkpoints to not have "Inf" before going ahead
-        
-        annual.my.stats <- apply(cur.prcp,2,function(x){
-          amax <- aggregate(x,FUN=max,by=list(my.years))[,2]
+      if (is.null(my.range)) {
+        my.range <- 1:dim(prcp[[1]])[1]
+      }
+      stat.rp.rl.list <- mclapply(X = 1:d, mc.preschedule = TRUE, mc.cores = mc.cores, FUN = function(i) {
+        cur.prcp <- as.matrix(prcp[[i]][my.range, ])
+        if (sum(is.infinite(cur.prcp)) > 0) {
+          idx.dummy <- which(is.infinite(cur.prcp), arr.ind = T)
+          cur.prcp[idx.dummy[, 1], idx.dummy[, 2]] <- NA
+        } # checkpoints to not have "Inf" before going ahead
+
+        annual.my.stats <- apply(cur.prcp, 2, function(x) {
+          amax <- aggregate(x, FUN = max, by = list(my.years))[, 2]
           return(amax)
         })
       })
       my.stats <- unlist(stat.rp.rl.list)
-      dim(my.stats) <- c(length(uniq.years),n.sites,d)
+      dim(my.stats) <- c(length(uniq.years), n.sites, d)
       return(my.stats)
     }
-    
+
     # obs annual max
-    psite.obs.amax <- aggregate(mean.prcp.site,FUN=max,by=list(wateryears.obs))[,2]
+    psite.obs.amax <- aggregate(mean.prcp.site, FUN = max, by = list(wateryears.obs))[, 2]
     # sim annual max
-    prcp.sim.annmax0 <- fct.prcp.sim.annmax(prcp=list(mean.prcp.site.sim),my.years=wateryears.sim)
-    prcp.sim.annmax <- apply(prcp.sim.annmax0,2,FUN=as.vector)
-    ymax <- max(c(psite.obs.amax,prcp.sim.annmax),na.rm=T)
-    
+    prcp.sim.annmax0 <- fct.prcp.sim.annmax(prcp = list(mean.prcp.site.sim), my.years = wateryears.sim)
+    prcp.sim.annmax <- apply(prcp.sim.annmax0, 2, FUN = as.vector)
+    ymax <- max(c(psite.obs.amax, prcp.sim.annmax), na.rm = T)
+
     require(ismev)
-    my.gev.fit1 <- gev.fit(psite.obs.amax,show = F)
-    my.gev.rl(my.gev.fit1$mle, my.gev.fit1$cov, my.gev.fit1$data,ymax,site.num)
+    my.gev.fit1 <- gev.fit(psite.obs.amax, show = F)
+    my.gev.rl(my.gev.fit1$mle, my.gev.fit1$cov, my.gev.fit1$data, ymax, site.num)
     dat <- prcp.sim.annmax
     dat <- dat[!is.na(dat)]
-    points(-1/log((1:length(dat))/(length(dat) + 1)), sort(dat),
-           col="black",cex=0.75,pch=16)
-    
-    lines(my.ret.per,my.rl.vals[,2],col='blue',lwd=2,lty=1)
-    lines(my.ret.per,my.rl.vals[,1],col='blue',lwd=1,lty=3)
-    lines(my.ret.per,my.rl.vals[,3],col='blue',lwd=1,lty=3)
-    
-    myTicks = axTicks(1)
-    axis(1, at = myTicks, labels = formatC(myTicks, format = 'd'),cex.axis=1.75)
-    legend("topleft", legend=c(label1,label11,label12,label2),
-           col=c("red", "red",'blue',"black"), 
-           lty=c(NA,1,1,NA),cex=1.5,pch=c(4,NA,NA,16),
-           lwd=c(NA,1.5,2,NA),
-           bty = "n",horiz = FALSE,
-           title='at-basin',title.col = 'purple')
+    points(-1 / log((1:length(dat)) / (length(dat) + 1)), sort(dat),
+      col = "black", cex = 0.75, pch = 16
+    )
 
-    
+    lines(my.ret.per, my.rl.vals[, 2], col = "blue", lwd = 2, lty = 1)
+    lines(my.ret.per, my.rl.vals[, 1], col = "blue", lwd = 1, lty = 3)
+    lines(my.ret.per, my.rl.vals[, 3], col = "blue", lwd = 1, lty = 3)
+
+    myTicks <- axTicks(1)
+    axis(1, at = myTicks, labels = formatC(myTicks, format = "d"), cex.axis = 1.75)
+    legend("topleft",
+      legend = c(label1, label11, label12, label2),
+      col = c("red", "red", "blue", "black"),
+      lty = c(NA, 1, 1, NA), cex = 1.5, pch = c(4, NA, NA, 16),
+      lwd = c(NA, 1.5, 2, NA),
+      bty = "n", horiz = FALSE,
+      title = "at-basin", title.col = "purple"
+    )
+
+
     # (b)
     #----------------------------------------- #
     ## -- correlation between extremes -- ##
     #----------------------------------------- #
     resampled.date.sim_sfx <- "/resampled.date.sim.sim"
-    load(paste0(dir.to.sim.files,resampled.date.sim_sfx,simulated.file.run.model.saved,".RData"))
-    resampled.dates <- match(as.Date(resampled.date.sim[[1]]),dates.weather)
-    quantile.nz <- function(x,p=qq){quantile(x[x!=0],p,na.rm=T)}
-    thshd.prcp <- apply(prcp.site.data,2,FUN=quantile.nz)
-    pot.idx <- sapply(1:n.sites,function(x,v){(prcp.site.data[,x]>v[x])
-    },v=thshd.prcp)
-    pot.idx.boot <- pot.idx[resampled.dates,]
-    prcp.site.boot <- prcp.site.data[resampled.dates,]
+    load(paste0(dir.to.sim.files, resampled.date.sim_sfx, simulated.file.run.model.saved, ".RData"))
+    resampled.dates <- match(as.Date(resampled.date.sim[[1]]), dates.weather)
+    quantile.nz <- function(x, p = qq) {
+      quantile(x[x != 0], p, na.rm = T)
+    }
+    thshd.prcp <- apply(prcp.site.data, 2, FUN = quantile.nz)
+    pot.idx <- sapply(1:n.sites, function(x, v) {
+      (prcp.site.data[, x] > v[x])
+    }, v = thshd.prcp)
+    pot.idx.boot <- pot.idx[resampled.dates, ]
+    prcp.site.boot <- prcp.site.data[resampled.dates, ]
     prcp.site.data.sim.ex <- prcp.site.data.sim
     prcp.site.data.sim.ex <- prcp.site.data.sim.ex[pot.idx.boot]
     prcp.site.boot.ex.specific <- prcp.site.boot[pot.idx.boot]
-    vall <- round(cor(prcp.site.boot.ex.specific,prcp.site.data.sim.ex),2)
-    
-    plot(prcp.site.data.sim.ex,prcp.site.boot.ex.specific,
-         xlim=c(min(prcp.site.data.sim.ex),
-                max(prcp.site.data.sim.ex)),
-         ylim=c(min(prcp.site.data.sim.ex),
-                max(prcp.site.data.sim.ex)),
-         ylab=paste0(label1,'(boot), max=',round(max(prcp.site.boot.ex.specific),1)),
-         xlab=paste0(label2,', max=',round(max(prcp.site.data.sim.ex),1)),
-         cex.axis=1.75,cex.lab=1.5,cex.main=2,font.main=1,cex.sub=1.15,
-         pch=19,col=NULL,cex=1.5,
-         frame=T,main=paste0('Precipitation Extremes'),
-         sub=paste0('cor=',vall),col.sub='purple')
-    abline(a=0,b=1, col='gray75',lwd=1.5, lty=2)
-    points(prcp.site.data.sim.ex,prcp.site.boot.ex.specific,
-           pch=19,col=alpha('darkblue',0.25),cex=1.5)
-    legend("topleft", legend=c('peak-over-threshold events'),
-           col=c('darkblue'),cex=1.5,pch=c(19),
-           bty = "n",horiz = FALSE,
-           title='at-site',title.col = 'purple')
-    
+    vall <- round(cor(prcp.site.boot.ex.specific, prcp.site.data.sim.ex), 2)
+
+    plot(prcp.site.data.sim.ex, prcp.site.boot.ex.specific,
+      xlim = c(
+        min(prcp.site.data.sim.ex),
+        max(prcp.site.data.sim.ex)
+      ),
+      ylim = c(
+        min(prcp.site.data.sim.ex),
+        max(prcp.site.data.sim.ex)
+      ),
+      ylab = paste0(label1, "(boot), max=", round(max(prcp.site.boot.ex.specific), 1)),
+      xlab = paste0(label2, ", max=", round(max(prcp.site.data.sim.ex), 1)),
+      cex.axis = 1.75, cex.lab = 1.5, cex.main = 2, font.main = 1, cex.sub = 1.15,
+      pch = 19, col = NULL, cex = 1.5,
+      frame = T, main = paste0("Precipitation Extremes"),
+      sub = paste0("cor=", vall), col.sub = "purple"
+    )
+    abline(a = 0, b = 1, col = "gray75", lwd = 1.5, lty = 2)
+    points(prcp.site.data.sim.ex, prcp.site.boot.ex.specific,
+      pch = 19, col = alpha("darkblue", 0.25), cex = 1.5
+    )
+    legend("topleft",
+      legend = c("peak-over-threshold events"),
+      col = c("darkblue"), cex = 1.5, pch = c(19),
+      bty = "n", horiz = FALSE,
+      title = "at-site", title.col = "purple"
+    )
+
     # (c)
     #----------------------------------------- #
     ## -- short/long-term extreme -- ##
     #----------------------------------------- #
     # less than a year: n-days/years precip max
-    prcp.max.extreme.diagnostics <- function(prcp,my.years,my.range=NULL,mc.cores=1) {
+    prcp.max.extreme.diagnostics <- function(prcp, my.years, my.range = NULL, mc.cores = 1) {
       d <- length(prcp)
       n.sites <- dim(prcp[[1]])[2]
-      ma.options.rolling <- c(7,10,30,90,180,seq(1,1)*365) # n-day moving averages
-      stat.names2 <- c(paste0(c(7,10),'.day.max'),
-                       paste0(c(1,3,6),'.month.max'),
-                       paste0(seq(1,1),'.year.max'))
-      #calculate at-site statistics: min
+      ma.options.rolling <- c(7, 10, 30, 90, 180, seq(1, 1) * 365) # n-day moving averages
+      stat.names2 <- c(
+        paste0(c(7, 10), ".day.max"),
+        paste0(c(1, 3, 6), ".month.max"),
+        paste0(seq(1, 1), ".year.max")
+      )
+      # calculate at-site statistics: min
       n.stats <- length(stat.names2)
-      if(is.null(my.range)) {my.range <- 1:dim(prcp[[1]])[1]}
-      stat.list2 <- mclapply(X=1:d,mc.preschedule=TRUE,mc.cores=mc.cores,FUN=function(i){  
-        my.stats2 <- array(NA,c(n.sites,n.stats))
-        cur.prcp <- matrix(prcp[[i]][my.range,])
-        if (sum(is.infinite(cur.prcp))>0){
-          idx.dummy <- which(is.infinite(cur.prcp),arr.ind = T)
-          cur.prcp[idx.dummy[,1],idx.dummy[,2]] <- NA} # checkpoints to not have "Inf" before going ahead
+      if (is.null(my.range)) {
+        my.range <- 1:dim(prcp[[1]])[1]
+      }
+      stat.list2 <- mclapply(X = 1:d, mc.preschedule = TRUE, mc.cores = mc.cores, FUN = function(i) {
+        my.stats2 <- array(NA, c(n.sites, n.stats))
+        cur.prcp <- matrix(prcp[[i]][my.range, ])
+        if (sum(is.infinite(cur.prcp)) > 0) {
+          idx.dummy <- which(is.infinite(cur.prcp), arr.ind = T)
+          cur.prcp[idx.dummy[, 1], idx.dummy[, 2]] <- NA
+        } # checkpoints to not have "Inf" before going ahead
         for (s in 1:n.stats) {
-          my.stats2[,s] <- apply(cur.prcp,2,function(x){max(rollapply(data=x, FUN = mean, width = ma.options.rolling[s],na.rm=T))})
+          my.stats2[, s] <- apply(cur.prcp, 2, function(x) {
+            max(rollapply(data = x, FUN = mean, width = ma.options.rolling[s], na.rm = T))
+          })
         }
         colnames(my.stats2) <- stat.names2
         return(my.stats2)
       })
       my.stats2 <- unlist(stat.list2)
-      dim(my.stats2) <- c(n.sites,n.stats,d)    
+      dim(my.stats2) <- c(n.sites, n.stats, d)
       dimnames(my.stats2)[[2]] <- stat.names2
       return(my.stats2)
     }
-    
-    stat.names2 <-c(paste0(c(7,10),'-day max'),
-                    paste0(c(1,3,6),'-month max'),
-                    paste0(seq(1,1),'-year max'))
+
+    stat.names2 <- c(
+      paste0(c(7, 10), "-day max"),
+      paste0(c(1, 3, 6), "-month max"),
+      paste0(seq(1, 1), "-year max")
+    )
     years.sim <- wateryears.sim
     years.obs <- wateryears.obs
-    obs.diagnostics.min <- prcp.max.extreme.diagnostics(prcp=list(mean.prcp.site),my.years=years.weather)
-    obs.array <-  obs.diagnostics.min.extreme <- as.matrix(obs.diagnostics.min[,,1])
-    sim.diagnostics.min <- prcp.max.extreme.diagnostics(prcp=list(mean.prcp.site.sim),my.years=years.sim)
-    sim.array <- sim.diagnostics.min[1,,]
+    obs.diagnostics.min <- prcp.max.extreme.diagnostics(prcp = list(mean.prcp.site), my.years = years.weather)
+    obs.array <- obs.diagnostics.min.extreme <- as.matrix(obs.diagnostics.min[, , 1])
+    sim.diagnostics.min <- prcp.max.extreme.diagnostics(prcp = list(mean.prcp.site.sim), my.years = years.sim)
+    sim.array <- sim.diagnostics.min[1, , ]
     my.pch <- 15:20
-    nd.selec <- c(1,2,3,4,5,6,7,8,10)
-    my.x.y.min.max <- c(min(sim.array,obs.array),max(sim.array,obs.array))
-    
-    plot(sim.array,obs.array,
-         xlim=my.x.y.min.max,ylim=my.x.y.min.max,
-         pch=my.pch,col=rainbow(length(nd.selec)),frame=F,
-         main='Short/Long-term Maxima',sub='',cex.sub=1.5,xlab=label2,ylab='',
-         cex.axis=1.75,cex.lab=1.5,cex.main=2,cex=3.5,font.main=1)
-    mtext(label1, side=2, line=3, cex=1.5)
-    abline(a=0,b=1, col='gray75',lwd=1.5, lty=2)
-    legend('topleft',legend=paste(stat.names2),pch=my.pch,cex=1.5,col=rainbow(length(nd.selec)),
-           inset=c(0.025,0), xpd=TRUE,horiz = FALSE,title='at-basin',title.col = 'purple')
-    
-    
+    nd.selec <- c(1, 2, 3, 4, 5, 6, 7, 8, 10)
+    my.x.y.min.max <- c(min(sim.array, obs.array), max(sim.array, obs.array))
+
+    plot(sim.array, obs.array,
+      xlim = my.x.y.min.max, ylim = my.x.y.min.max,
+      pch = my.pch, col = rainbow(length(nd.selec)), frame = F,
+      main = "Short/Long-term Maxima", sub = "", cex.sub = 1.5, xlab = label2, ylab = "",
+      cex.axis = 1.75, cex.lab = 1.5, cex.main = 2, cex = 3.5, font.main = 1
+    )
+    mtext(label1, side = 2, line = 3, cex = 1.5)
+    abline(a = 0, b = 1, col = "gray75", lwd = 1.5, lty = 2)
+    legend("topleft",
+      legend = paste(stat.names2), pch = my.pch, cex = 1.5, col = rainbow(length(nd.selec)),
+      inset = c(0.025, 0), xpd = TRUE, horiz = FALSE, title = "at-basin", title.col = "purple"
+    )
+
+
     # (d)
     #----------------------------------------- #
     ## -- wet spells -- ##
     #----------------------------------------- #
-    spells.labels <- c('mean.wet.spell','max.wet.spell',
-                       'mean.dry.spell','max.dry.spell')
-    fct.spell.stats <- function(prcp.file){
-      prcp.thresh <- 0    #trace precipitation threshold (0 inches)
-      apply(prcp.file,2,function(x) {
+    spells.labels <- c(
+      "mean.wet.spell", "max.wet.spell",
+      "mean.dry.spell", "max.dry.spell"
+    )
+    fct.spell.stats <- function(prcp.file) {
+      prcp.thresh <- 0 # trace precipitation threshold (0 inches)
+      apply(prcp.file, 2, function(x) {
         y <- x[!is.na(x)]
         nn <- length(y)
         wet.dry <- y
-        wet.dry[wet.dry<=prcp.thresh] <- 0
-        wet.dry[wet.dry>prcp.thresh] <- 1
-        first.of.run <- c(1,which(diff(wet.dry)!=0) + 1)
-        last.of.run <- c(which(diff(wet.dry)!=0),nn)
-        run.length <- last.of.run-first.of.run + 1
+        wet.dry[wet.dry <= prcp.thresh] <- 0
+        wet.dry[wet.dry > prcp.thresh] <- 1
+        first.of.run <- c(1, which(diff(wet.dry) != 0) + 1)
+        last.of.run <- c(which(diff(wet.dry) != 0), nn)
+        run.length <- last.of.run - first.of.run + 1
         run.type <- wet.dry[first.of.run]
-        wet.dry.runs <- data.frame('type'=run.type,'first'=first.of.run,'last'=last.of.run,'length'=run.length)
+        wet.dry.runs <- data.frame("type" = run.type, "first" = first.of.run, "last" = last.of.run, "length" = run.length)
         result <- c(
-          mean(wet.dry.runs$length[wet.dry.runs$type==1]),
-          max(wet.dry.runs$length[wet.dry.runs$type==1]),
-          mean(wet.dry.runs$length[wet.dry.runs$type==0]),
-          max(wet.dry.runs$length[wet.dry.runs$type==0])
+          mean(wet.dry.runs$length[wet.dry.runs$type == 1]),
+          max(wet.dry.runs$length[wet.dry.runs$type == 1]),
+          mean(wet.dry.runs$length[wet.dry.runs$type == 0]),
+          max(wet.dry.runs$length[wet.dry.runs$type == 0])
         )
         return(result)
       })
     }
-    my.sim.col <- c('black')
-    my.obs.col <- c('red')
+    my.sim.col <- c("black")
+    my.obs.col <- c("red")
     obs.spell.stats <- fct.spell.stats(prcp.site.data)
     sim.spell.stats <- fct.spell.stats(prcp.site.data.sim)
-    x1 <- obs.spell.stats[1,]
-    x2 <- sim.spell.stats[1,]
-    x11 <- obs.spell.stats[2,]
-    x22 <- sim.spell.stats[2,]
-    
-    boxplot(x1,horizontal = T,main='',
-            col=alpha(my.obs.col,.2),
-            boxcol=my.obs.col,medcol=my.obs.col,
-            whiskcol=my.obs.col,staplecol=my.obs.col,outcol=my.obs.col,
-            boxwex=.35,xlab='Mean length (days)',
-            cex.axis=1.75,cex.lab=1.5,cex.main=2,font.main=1)
-    boxplot(x2,add=T,horizontal = T,
-            col=alpha(my.sim.col,.2),
-            boxcol=my.sim.col,medcol=my.sim.col,
-            whiskcol=my.sim.col,staplecol=my.sim.col,outcol=my.sim.col,
-            boxwex=.2,
-            cex.axis=1.75,cex.lab=1.5,cex.main=2,font.main=1)
-    text(mean(c(x1,x2)),0.5,cex=1.5,col='blue',
-         paste0('max. Obs=',round(max(x11),1),
-                ', max. Sim=',round(max(x22),1)))
-    mtext('Wet Spells',3,cex=1.75,line = 1)
-    legend("topleft", legend=c(label1,label2),
-           fill=c("red", alpha(my.sim.col,.5)),cex=1.5,
-           bty = "n",horiz = FALSE,
-           title='at-site',title.col = 'purple')
-    
+    x1 <- obs.spell.stats[1, ]
+    x2 <- sim.spell.stats[1, ]
+    x11 <- obs.spell.stats[2, ]
+    x22 <- sim.spell.stats[2, ]
+
+    boxplot(x1,
+      horizontal = T, main = "",
+      col = alpha(my.obs.col, .2),
+      boxcol = my.obs.col, medcol = my.obs.col,
+      whiskcol = my.obs.col, staplecol = my.obs.col, outcol = my.obs.col,
+      boxwex = .35, xlab = "Mean length (days)",
+      cex.axis = 1.75, cex.lab = 1.5, cex.main = 2, font.main = 1
+    )
+    boxplot(x2,
+      add = T, horizontal = T,
+      col = alpha(my.sim.col, .2),
+      boxcol = my.sim.col, medcol = my.sim.col,
+      whiskcol = my.sim.col, staplecol = my.sim.col, outcol = my.sim.col,
+      boxwex = .2,
+      cex.axis = 1.75, cex.lab = 1.5, cex.main = 2, font.main = 1
+    )
+    text(mean(c(x1, x2)), 0.5,
+      cex = 1.5, col = "blue",
+      paste0(
+        "max. Obs=", round(max(x11), 1),
+        ", max. Sim=", round(max(x22), 1)
+      )
+    )
+    mtext("Wet Spells", 3, cex = 1.75, line = 1)
+    legend("topleft",
+      legend = c(label1, label2),
+      fill = c("red", alpha(my.sim.col, .5)), cex = 1.5,
+      bty = "n", horiz = FALSE,
+      title = "at-site", title.col = "purple"
+    )
+
     dev.off()
   }
-  
-  
-  # Figure 2:
+
+
+  #### Figure 2: ---------------------------------------------------------------
   # 2) precipitation cdf, mean, standard variation (yearly, year-to-year)
+  cat("\nScenario: ", scenario, "| 2) precipitation cdf, mean, standard variation (yearly, year-to-year)\n\n")
   {
-    
-    file.name.fig <- paste0("lines_prcp.mean_cdf_sd_",n.sites,".files_s",
-                            num.states,"_with_",num.iter,"_ens.png")
-    fname.fig <- paste0("./Figures/",file.name.fig)
-    ww.mom <- 14; hh.mom <- 14
-    png(fname.fig,width=ww.mom,height=hh.mom,units="in",res=300)
-    par(mfcol=c(2,2),mai=c(1,1,1,0.5))
-    
-    
+    file.name.fig <- paste0(
+      "lines_prcp.mean_cdf_sd_", n.sites, ".files_s",
+      num.states, "_with_", num.iter, "_ens.png"
+    )
+    fname.fig <- paste0(dir.to.figures, "/", file.name.fig)
+    ww.mom <- 14
+    hh.mom <- 14
+    png(fname.fig, width = ww.mom, height = hh.mom, units = "in", res = 300)
+    par(mfcol = c(2, 2), mai = c(1, 1, 1, 0.5))
+
+
     # (a)
     #------------------------------------------ #
     ## -- cdf of precipitation distribution -- ##
     #------------------------------------------ #
-    annual.prcp <- aggregate(mean.prcp.site,FUN=sum,by=list(wateryears.obs))[,2]
-    annual.prcp <- annual.prcp[2:(length(annual.prcp)-1)]   #drop first and last to only keep full water years
-    annual.prcp.boot.sort <- array(NA,c(length(annual.prcp),1000))
-    annual.prcp.sd <- array(NA,1000)
+    annual.prcp <- aggregate(mean.prcp.site, FUN = sum, by = list(wateryears.obs))[, 2]
+    annual.prcp <- annual.prcp[2:(length(annual.prcp) - 1)] # drop first and last to only keep full water years
+    annual.prcp.boot.sort <- array(NA, c(length(annual.prcp), 1000))
+    annual.prcp.sd <- array(NA, 1000)
     for (i in 1:1000) {
-      annual.prcp.boot.sort[,i] <- sort(sample(annual.prcp,size=length(annual.prcp),replace=TRUE))
-      annual.prcp.sd[i] <- sd(sample(annual.prcp,size=length(annual.prcp),replace=TRUE))
+      annual.prcp.boot.sort[, i] <- sort(sample(annual.prcp, size = length(annual.prcp), replace = TRUE))
+      annual.prcp.sd[i] <- sd(sample(annual.prcp, size = length(annual.prcp), replace = TRUE))
     }
-    boot.95 <- apply(annual.prcp.boot.sort,1,FUN=quantile,.95)
-    boot.05 <- apply(annual.prcp.boot.sort,1,FUN=quantile,.05)
-    #get annual total prcp from simulation
+    boot.95 <- apply(annual.prcp.boot.sort, 1, FUN = quantile, .95)
+    boot.05 <- apply(annual.prcp.boot.sort, 1, FUN = quantile, .05)
+    # get annual total prcp from simulation
     prcp.basin.sim <- mean.prcp.site.sim
-    annual.prcp.sim <- aggregate(prcp.basin.sim,FUN=sum,by=list(wateryears.sim),na.rm=T)[,2]
-    annual.prcp.sim <- annual.prcp.sim[2:(length(annual.prcp.sim)-1)] #drop first and last to only keep full water years
-    
-    
+    annual.prcp.sim <- aggregate(prcp.basin.sim, FUN = sum, by = list(wateryears.sim), na.rm = T)[, 2]
+    annual.prcp.sim <- annual.prcp.sim[2:(length(annual.prcp.sim) - 1)] # drop first and last to only keep full water years
+
+
     y.hat <- annual.prcp
-    EP.hat <- (1:length(y.hat))/(length(y.hat)+1)
+    EP.hat <- (1:length(y.hat)) / (length(y.hat) + 1)
     y <- annual.prcp.sim
-    EP <- (1:length(y))/(length(y)+1)
-    plot(EP.hat,sort(y.hat),log="y",type='l',frame=F,
-         col="red",lwd=5,xlab='Exceedance Probability',ylab='Precipitation [WY]',
-         cex.axis=2,cex.main=4,cex.lab=2, font.main=1)
-    lines(EP,sort(y),lty=1, col='gray50',lwd=6)
-    polygon(x=c(EP.hat,rev(EP.hat)),y=c(boot.05,rev(boot.95)),
-            col=alpha('red',0.15),border=NA)
-    legend('topleft',c(paste0(label1,' (boot)'),paste0(label2)),
-           horiz = F,
-           # cex=1.75,
-           cex=2.25,
-           # title=paste0('at-basin'),
-           # title.col = 'purple',title.cex = 2.5,
-           fill=c('red','black'),bty = 'n')
-    
+    EP <- (1:length(y)) / (length(y) + 1)
+    plot(EP.hat, sort(y.hat),
+      log = "y", type = "l", frame = F,
+      col = "red", lwd = 5, xlab = "Exceedance Probability", ylab = "Precipitation [WY]",
+      cex.axis = 2, cex.main = 4, cex.lab = 2, font.main = 1
+    )
+    lines(EP, sort(y), lty = 1, col = "gray50", lwd = 6)
+    polygon(
+      x = c(EP.hat, rev(EP.hat)), y = c(boot.05, rev(boot.95)),
+      col = alpha("red", 0.15), border = NA
+    )
+    legend("topleft", c(paste0(label1, " (boot)"), paste0(label2)),
+      horiz = F,
+      # cex=1.75,
+      cex = 2.25,
+      # title=paste0('at-basin'),
+      # title.col = 'purple',title.cex = 2.5,
+      fill = c("red", "black"), bty = "n"
+    )
+
     # (b)
     #----------------------------------------- #
     ## -- year-to-year SD of precipitation -- ##
     #----------------------------------------- #
-    annual.prcp <- aggregate(mean.prcp.site,FUN=sum,by=list(wateryears.obs))[,2]
-    annual.prcp <- annual.prcp[2:(length(annual.prcp)-1)]   #drop first and last to only keep full water years
-    annual.prcp.sd <- array(NA,1000)
+    annual.prcp <- aggregate(mean.prcp.site, FUN = sum, by = list(wateryears.obs))[, 2]
+    annual.prcp <- annual.prcp[2:(length(annual.prcp) - 1)] # drop first and last to only keep full water years
+    annual.prcp.sd <- array(NA, 1000)
     for (i in 1:1000) {
-      annual.prcp.sd[i] <- sd(sample(annual.prcp,size=length(annual.prcp),replace=TRUE))
+      annual.prcp.sd[i] <- sd(sample(annual.prcp, size = length(annual.prcp), replace = TRUE))
     }
-    #get annual total prcp from simulation
+    # get annual total prcp from simulation
     prcp.basin.sim <- mean.prcp.site.sim
-    annual.prcp.sim <- aggregate(prcp.basin.sim,FUN=sum,by=list(wateryears.sim),na.rm=T)[,2]
-    annual.prcp.sim <- annual.prcp.sim[2:(length(annual.prcp.sim)-1)] #drop first and last to only keep full water years
-    
+    annual.prcp.sim <- aggregate(prcp.basin.sim, FUN = sum, by = list(wateryears.sim), na.rm = T)[, 2]
+    annual.prcp.sim <- annual.prcp.sim[2:(length(annual.prcp.sim) - 1)] # drop first and last to only keep full water years
+
     boxplot(annual.prcp.sd,
-            col=alpha('red',0.2),boxwex=0.5,boxcol=alpha('red',0.5),
-            outcol=alpha('red',0.5),outcex=1.15, outpch=21,medcol=alpha('red',0.5),
-            outbg=alpha('red',0.5),whiskcol=alpha('red',0.5),whisklty=1,staplecol=alpha('red',0.5),
-            frame=F,main='',
-            xlab='',ylab='annual stdev [Total Precipitation]',cex.axis=2,cex.main=2.5,cex.lab=1.65, font.main=1)
-    points(sd(annual.prcp),col="red",pch=16,cex=3)
-    points(sd(annual.prcp.sim),col="black",pch=16,cex=3)
-    legend('topleft',c(paste0(label1,' (boot)'),paste0(label2)),
-           horiz = F,
-           # cex=1.75,
-           cex=2.25,
-           # title=paste0('at-basin'),
-           # title.col = 'purple',title.cex = 2.5,
-           fill=c('red','black'),bty = 'n')
-    
-    
+      col = alpha("red", 0.2), boxwex = 0.5, boxcol = alpha("red", 0.5),
+      outcol = alpha("red", 0.5), outcex = 1.15, outpch = 21, medcol = alpha("red", 0.5),
+      outbg = alpha("red", 0.5), whiskcol = alpha("red", 0.5), whisklty = 1, staplecol = alpha("red", 0.5),
+      frame = F, main = "",
+      xlab = "", ylab = "annual stdev [Total Precipitation]", cex.axis = 2, cex.main = 2.5, cex.lab = 1.65, font.main = 1
+    )
+    points(sd(annual.prcp), col = "red", pch = 16, cex = 3)
+    points(sd(annual.prcp.sim), col = "black", pch = 16, cex = 3)
+    legend("topleft", c(paste0(label1, " (boot)"), paste0(label2)),
+      horiz = F,
+      # cex=1.75,
+      cex = 2.25,
+      # title=paste0('at-basin'),
+      # title.col = 'purple',title.cex = 2.5,
+      fill = c("red", "black"), bty = "n"
+    )
+
+
     # (c...)
     #--------------------------------------- #
     ## -- whiskers of long trace metrics -- ##
     #--------------------------------------- #
-    lst.annual.obs <- lst.annual.sim <- list()
-    lst.annual.obs[[1]] <- aggregate(prcp.site.data,FUN=mean,by=list(wateryears.obs))[,-1]
-    lst.annual.sim[[1]] <- aggregate(prcp.site.data.sim,FUN=mean,by=list(wateryears.sim))[,-1]
-    lst.annual.obs[[2]] <- aggregate(prcp.site.data,FUN=sd,by=list(wateryears.obs))[,-1]
-    lst.annual.sim[[2]] <- aggregate(prcp.site.data.sim,FUN=sd,by=list(wateryears.sim))[,-1]
-    
-    labs.metrics <- c('mean','stdev')
-    
-    for (k in 1:length(labs.metrics)){
+    labs.metrics <- c("mean", "stdev")
+    lst.annual.obs <- lst.annual.sim <- vector("list", length(labs.metrics))
+    lst.annual.obs[[1]] <- aggregate(prcp.site.data, FUN = mean, by = list(wateryears.obs))[, -1]
+    lst.annual.sim[[1]] <- aggregate(prcp.site.data.sim, FUN = mean, by = list(wateryears.sim))[, -1]
+    lst.annual.obs[[2]] <- aggregate(prcp.site.data, FUN = sd, by = list(wateryears.obs))[, -1]
+    lst.annual.sim[[2]] <- aggregate(prcp.site.data.sim, FUN = sd, by = list(wateryears.sim))[, -1]
+
+    for (k in 1:length(labs.metrics)) {
       annual.obs <- lst.annual.obs[[k]]
       annual.sim <- lst.annual.sim[[k]]
       my.sim.y <- annual.sim
       my.obs.y <- annual.obs
-      
-      my1.x0 <- apply(my.sim.y,2,FUN=median)
-      my1.y0 <- apply(my.obs.y,2,FUN=quantile,0.05)
-      my1.y1 <- apply(my.obs.y,2,FUN=quantile,0.95)
-      
-      my2.x0 <- my2.x1 <- apply(my.obs.y,2,FUN=median)
-      my2.y0 <- apply(my.sim.y,2,FUN=quantile,0.05)
-      my2.y1 <- apply(my.sim.y,2,FUN=quantile,0.95)
-      x_y_lim <- c(min(c(my1.y0,my2.y0)),max(c(my1.y1,my2.y1)))
-      
-      plot(my1.x0, my2.x0, xlim=x_y_lim, ylim=x_y_lim,
-           pch=1, cex=2.25, frame=T,col=NULL,
-           xlab='',ylab='',
-           cex.axis=2,
-           main=paste0(labs.metrics[k]),sub='|5th, median, 95th|',col.sub=alpha('blue',0.5),
-           cex.lab=2, cex.main=3, font.main=1,cex.sub=1.75)
-      mtext(paste0(label2),1,col='gray60',line=2.25, cex=1.75)
-      mtext(label1,2,col='red',line=2.25, cex=1.75)
-      arrows(x0=my2.y0,
-             y0=my2.x0, x1=my2.y1, y1=my2.x0, code=3, angle=90, length=0.025, col=alpha("gray40",0.75), lwd=0.5)
-      arrows(x0=my1.x0,
-             y0=my1.y0, x1=my1.x0, y1=my1.y1, code=3, angle=90, length=0.025, col=alpha("red",0.75), lwd=0.5)
-      abline(0,1,lwd=1.5,lty=2)
-      points(my1.x0, my2.x0, xlim=x_y_lim, ylim=x_y_lim, pch=19, 
-             cex=1.5,col=alpha("gray40",0.65))
-      legend("topleft",legend=c(NA) ,title=paste0('at-site'),pch=19,cex=2.5,
-             col='gray40',title.col = 'purple',inset=0.01,
-             horiz = FALSE)
+
+      my1.x0 <- apply(my.sim.y, 2, FUN = median)
+      my1.y0 <- apply(my.obs.y, 2, FUN = quantile, 0.05)
+      my1.y1 <- apply(my.obs.y, 2, FUN = quantile, 0.95)
+
+      my2.x0 <- my2.x1 <- apply(my.obs.y, 2, FUN = median)
+      my2.y0 <- apply(my.sim.y, 2, FUN = quantile, 0.05)
+      my2.y1 <- apply(my.sim.y, 2, FUN = quantile, 0.95)
+      x_y_lim <- c(min(c(my1.y0, my2.y0)), max(c(my1.y1, my2.y1)))
+
+      plot(my1.x0, my2.x0,
+        xlim = x_y_lim, ylim = x_y_lim,
+        pch = 1, cex = 2.25, frame = T, col = NULL,
+        xlab = "", ylab = "",
+        cex.axis = 2,
+        main = paste0(labs.metrics[k]), sub = "|5th, median, 95th|", col.sub = alpha("blue", 0.5),
+        cex.lab = 2, cex.main = 3, font.main = 1, cex.sub = 1.75
+      )
+      mtext(paste0(label2), 1, col = "gray60", line = 2.25, cex = 1.75)
+      mtext(label1, 2, col = "red", line = 2.25, cex = 1.75)
+      arrows(
+        x0 = my2.y0,
+        y0 = my2.x0, x1 = my2.y1, y1 = my2.x0, code = 3, angle = 90, length = 0.025, col = alpha("gray40", 0.75), lwd = 0.5
+      )
+      arrows(
+        x0 = my1.x0,
+        y0 = my1.y0, x1 = my1.x0, y1 = my1.y1, code = 3, angle = 90, length = 0.025, col = alpha("red", 0.75), lwd = 0.5
+      )
+      abline(0, 1, lwd = 1.5, lty = 2)
+      points(my1.x0, my2.x0,
+        xlim = x_y_lim, ylim = x_y_lim, pch = 19,
+        cex = 1.5, col = alpha("gray40", 0.65)
+      )
+      legend("topleft",
+        legend = c(NA), title = paste0("at-site"), pch = 19, cex = 2.5,
+        col = "gray40", title.col = "purple", inset = 0.01,
+        horiz = FALSE
+      )
     }
-    
-    
+
     dev.off()
   }
-  
-  # Figure 3:
+
+  #### Figure 3: ---------------------------------------------------------------
   # 3) water-year cumulative precipitations, monthly distributions
+  cat("\nScenario: ", scenario, "| 3) water-year cumulative precipitations, monthly distributions\n\n")
   {
     # label1 <- 'Obs [1948-2018]'
     # label2 <- 'Sim (WGEN: baseline)'
-    
-    file.name.fig <- paste0("lines_prcp.cumulative_seasonality_",n.sites,".files_s",
-                            num.states,"_with_",num.iter,"_ens.png")
-    fname.fig <- paste0("./Figures/",file.name.fig)
-    ww.mom <- 15; hh.mom <- 14
-    png(fname.fig,width=ww.mom,height=hh.mom,units="in",res=300)
-    par(mfcol=c(2,1),mai=c(1,1,0.75,0.5))
-    
+
+    file.name.fig <- paste0(
+      "lines_prcp.cumulative_seasonality_", n.sites, ".files_s",
+      num.states, "_with_", num.iter, "_ens.png"
+    )
+    fname.fig <- paste0(dir.to.figures, "/", file.name.fig)
+    ww.mom <- 15
+    hh.mom <- 14
+    png(fname.fig, width = ww.mom, height = hh.mom, units = "in", res = 300)
+    par(mfcol = c(2, 1), mai = c(1, 1, 0.75, 0.5))
+
     # (a)
     #--------------------------------------------- #
     ## -- water-year cumulative precipitations -- ##
     #--------------------------------------------- #
-    sample.WY.dates <- c(dates.weather[275:366],dates.weather[1:274]) # with leap year: 1948
-    sample.WY.months.days <- format(sample.WY.dates,'%m-%d')
-    sample.WY.months <- format(sample.WY.dates,'%m')
-    sample.WY.Months <- format(sample.WY.dates,'%b')
-    doy.WY.sample.idx <- as.numeric(format(c(dates.weather[275:366],dates.weather[1:274]),'%j'))
+    sample.WY.dates <- c(dates.weather[275:366], dates.weather[1:274]) # with leap year: 1948
+    sample.WY.months.days <- format(sample.WY.dates, "%m-%d")
+    sample.WY.months <- format(sample.WY.dates, "%m")
+    sample.WY.Months <- format(sample.WY.dates, "%b")
+    doy.WY.sample.idx <- as.numeric(format(c(dates.weather[275:366], dates.weather[1:274]), "%j"))
     seq.days <- sort(doy.WY.sample.idx)
-    
-    start_wy <- which(format(dates.weather,'%m-%d')=='10-01')
-    end_wy <- which(format(dates.weather,'%m-%d')=='09-30')
-    num.WY.available <- length(start_wy)-1
-    cumsum.WY.obs.sites <- array(NA,c(num.WY.available,n.sites,366))
-    for(y in 1:num.WY.available){
-      extracted.wy.dates <- dates.weather[start_wy[y]:end_wy[y+1]]
-      doy.WY.single.wy.idx <- as.numeric(format(extracted.wy.dates,'%j'))
-      for (k in 1:n.sites){
-        single.wy <- prcp.site.data[start_wy[y]:end_wy[y+1],k]
-        cumsum.WY.obs.sites[y,k,(1:length(single.wy))] <- cumsum(single.wy)
+
+    start_wy <- which(format(dates.weather, "%m-%d") == "10-01")
+    end_wy <- which(format(dates.weather, "%m-%d") == "09-30")
+    num.WY.available <- length(start_wy) - 1
+    cumsum.WY.obs.sites <- array(NA, c(num.WY.available, n.sites, 366))
+    for (y in 1:num.WY.available) {
+      extracted.wy.dates <- dates.weather[start_wy[y]:end_wy[y + 1]]
+      doy.WY.single.wy.idx <- as.numeric(format(extracted.wy.dates, "%j"))
+      for (k in 1:n.sites) {
+        single.wy <- prcp.site.data[start_wy[y]:end_wy[y + 1], k]
+        cumsum.WY.obs.sites[y, k, (1:length(single.wy))] <- cumsum(single.wy)
       }
     }
-    psite.obs.mean.metric2 <- apply(cumsum.WY.obs.sites,c(2,3),FUN=mean,na.rm=T)
-    psite.obs.metric2 <- apply(cumsum.WY.obs.sites,c(2,3),FUN=median,na.rm=T)
-    psite.obs.metric2.10th <- apply(cumsum.WY.obs.sites,c(2,3),FUN=quantile,0.1,na.rm=T)
-    psite.obs.metric2.90th <- apply(cumsum.WY.obs.sites,c(2,3),FUN=quantile,0.9,na.rm=T)
-    
+    psite.obs.mean.metric2 <- apply(cumsum.WY.obs.sites, c(2, 3), FUN = mean, na.rm = T)
+    psite.obs.metric2 <- apply(cumsum.WY.obs.sites, c(2, 3), FUN = median, na.rm = T)
+    psite.obs.metric2.10th <- apply(cumsum.WY.obs.sites, c(2, 3), FUN = quantile, 0.1, na.rm = T)
+    psite.obs.metric2.90th <- apply(cumsum.WY.obs.sites, c(2, 3), FUN = quantile, 0.9, na.rm = T)
+
     mean.psite.obs.metric2 <- as.matrix(apply(psite.obs.metric2, 2, mean))
     mean.psite.obs.metric2.10th <- as.matrix(apply(psite.obs.metric2.10th, 2, mean))
     mean.psite.obs.metric2.90th <- as.matrix(apply(psite.obs.metric2.90th, 2, mean))
     mean.psite.obs.mean.metric2 <- as.matrix(apply(psite.obs.mean.metric2, 2, mean))
-    
-    start_wy <- which(format(dates.sim,'%m-%d')=='10-01')
-    end_wy <- which(format(dates.sim,'%m-%d')=='09-30')
-    num.WY.available <- length(start_wy)-1
-    cumsum.WY.sim.sites <- array(NA,c(num.WY.available,n.sites,366))
-    for(y in 1:num.WY.available){
-      extracted.wy.dates <- dates.sim[start_wy[y]:end_wy[y+1]]
-      doy.WY.single.wy.idx <- as.numeric(format(extracted.wy.dates,'%j'))
-      
-      for (k in 1:n.sites){
-        
-        single.wy <- prcp.site.data.sim[start_wy[y]:end_wy[y+1],k]
-        cumsum.WY.sim.sites[y,k,(1:length(single.wy))] <- cumsum(single.wy)
+
+    start_wy <- which(format(dates.sim, "%m-%d") == "10-01")
+    end_wy <- which(format(dates.sim, "%m-%d") == "09-30")
+    num.WY.available <- length(start_wy) - 1
+    cumsum.WY.sim.sites <- array(NA, c(num.WY.available, n.sites, 366))
+    for (y in 1:num.WY.available) {
+      extracted.wy.dates <- dates.sim[start_wy[y]:end_wy[y + 1]]
+      doy.WY.single.wy.idx <- as.numeric(format(extracted.wy.dates, "%j"))
+
+      for (k in 1:n.sites) {
+        single.wy <- prcp.site.data.sim[start_wy[y]:end_wy[y + 1], k]
+        cumsum.WY.sim.sites[y, k, (1:length(single.wy))] <- cumsum(single.wy)
       }
     }
-    
-    psite.sim.mean.metric2 <- apply(cumsum.WY.sim.sites,c(2,3),FUN=mean,na.rm=T)
-    psite.sim.metric2 <- apply(cumsum.WY.sim.sites,c(2,3),FUN=median,na.rm=T)
-    psite.sim.metric2.10th <- apply(cumsum.WY.sim.sites,c(2,3),FUN=quantile,0.1,na.rm=T)
-    psite.sim.metric2.90th <- apply(cumsum.WY.sim.sites,c(2,3),FUN=quantile,0.9,na.rm=T)
-    
+
+    psite.sim.mean.metric2 <- apply(cumsum.WY.sim.sites, c(2, 3), FUN = mean, na.rm = T)
+    psite.sim.metric2 <- apply(cumsum.WY.sim.sites, c(2, 3), FUN = median, na.rm = T)
+    psite.sim.metric2.10th <- apply(cumsum.WY.sim.sites, c(2, 3), FUN = quantile, 0.1, na.rm = T)
+    psite.sim.metric2.90th <- apply(cumsum.WY.sim.sites, c(2, 3), FUN = quantile, 0.9, na.rm = T)
+
     mean.psite.sim.metric2 <- as.matrix(apply(psite.sim.metric2, 2, mean))
     mean.psite.sim.metric2.10th <- as.matrix(apply(psite.sim.metric2.10th, 2, mean))
     mean.psite.sim.metric2.90th <- as.matrix(apply(psite.sim.metric2.90th, 2, mean))
     mean.psite.sim.mean.metric2 <- as.matrix(apply(psite.sim.mean.metric2, 2, mean))
-    
-    start_months <- ceiling_date(sample.WY.dates %m-% months(1), 'month')
+
+    start_months <- ceiling_date(sample.WY.dates %m-% months(1), "month")
     idx.fst.d.month <- which(sample.WY.dates %in% start_months)
     my.seq.days <- 1:365
-    
+
     # median/mean
-    plot(my.seq.days,mean.psite.sim.metric2[my.seq.days],
-         type='l',col='black',cex=1.5,ylab='Precipitation [cumulative]',frame=F,
-         font.main = 1,sub='',xaxt = "n",xlab='Water Year',lwd=2,
-         ylim=c(min(c(mean.psite.sim.metric2.10th[my.seq.days],
-                      mean.psite.obs.metric2.10th[my.seq.days])),
-                max(c(mean.psite.sim.metric2.90th[my.seq.days],
-                      mean.psite.obs.metric2.90th[my.seq.days]))),
-         cex.lab=2,cex.axis=1.5,cex.main=3.5,
-         )
-    
-    axis(1,at = my.seq.days[idx.fst.d.month],col='gray50',cex.lab=3,cex.axis=2,
-         labels = sample.WY.Months[idx.fst.d.month])
-    
-    abline(v=my.seq.days[idx.fst.d.month],col='gray90',lty=2)
-    
-    lines(mean.psite.obs.metric2[my.seq.days],
-          col="red",cex=1,lwd=3.5)
-    
-    lines(mean.psite.sim.metric2.10th[my.seq.days],
-          col="gray25",cex=1,lwd=3,lty=2)
-    lines(mean.psite.sim.metric2.90th[my.seq.days],
-          col="gray25",cex=1,lwd=3,lty=2)
-    
-    lines(mean.psite.obs.metric2.10th[my.seq.days],
-          col=rgb(1,0,0,0.75),cex=2,lwd=3,lty=2)
-    lines(mean.psite.obs.metric2.90th[my.seq.days],
-          col=rgb(1,0,0,0.75),cex=2,lwd=3,lty=2)
-    
-    lines(mean.psite.obs.mean.metric2[my.seq.days],
-          col="tan1",cex=2,lwd=8, lty=1)
-    lines(mean.psite.sim.mean.metric2[my.seq.days],
-          col="blue",cex=2,lwd=3.5, lty=1)
-    
-    legend("topleft", legend=c(paste0(label2," (10,median,90th)"),
-                               paste0(label1," (10,median,90th)"),
-                               paste0(label2," (mean)"),
-                               paste0(label1," (mean)")),
-           col=c("black", "red","blue", "tan1"),
-           lty=c(1,1,1,1),lwd=c(2,2,2,4),
-           # cex=1.5,
-           cex=2,
-           horiz = FALSE,bty='n',
-           # title=paste0('at-basin'),
-           # title.col = 'purple',title.cex = 2
+    plot(my.seq.days, mean.psite.sim.metric2[my.seq.days],
+      type = "l", col = "black", cex = 1.5, ylab = "Precipitation [cumulative]", frame = F,
+      font.main = 1, sub = "", xaxt = "n", xlab = "Water Year", lwd = 2,
+      ylim = c(
+        min(c(
+          mean.psite.sim.metric2.10th[my.seq.days],
+          mean.psite.obs.metric2.10th[my.seq.days]
+        )),
+        max(c(
+          mean.psite.sim.metric2.90th[my.seq.days],
+          mean.psite.obs.metric2.90th[my.seq.days]
+        ))
+      ),
+      cex.lab = 2, cex.axis = 1.5, cex.main = 3.5,
     )
-    
+
+    axis(1,
+      at = my.seq.days[idx.fst.d.month], col = "gray50", cex.lab = 3, cex.axis = 2,
+      labels = sample.WY.Months[idx.fst.d.month]
+    )
+
+    abline(v = my.seq.days[idx.fst.d.month], col = "gray90", lty = 2)
+
+    lines(mean.psite.obs.metric2[my.seq.days],
+      col = "red", cex = 1, lwd = 3.5
+    )
+
+    lines(mean.psite.sim.metric2.10th[my.seq.days],
+      col = "gray25", cex = 1, lwd = 3, lty = 2
+    )
+    lines(mean.psite.sim.metric2.90th[my.seq.days],
+      col = "gray25", cex = 1, lwd = 3, lty = 2
+    )
+
+    lines(mean.psite.obs.metric2.10th[my.seq.days],
+      col = rgb(1, 0, 0, 0.75), cex = 2, lwd = 3, lty = 2
+    )
+    lines(mean.psite.obs.metric2.90th[my.seq.days],
+      col = rgb(1, 0, 0, 0.75), cex = 2, lwd = 3, lty = 2
+    )
+
+    lines(mean.psite.obs.mean.metric2[my.seq.days],
+      col = "tan1", cex = 2, lwd = 8, lty = 1
+    )
+    lines(mean.psite.sim.mean.metric2[my.seq.days],
+      col = "blue", cex = 2, lwd = 3.5, lty = 1
+    )
+
+    legend("topleft",
+      legend = c(
+        paste0(label2, " (10,median,90th)"),
+        paste0(label1, " (10,median,90th)"),
+        paste0(label2, " (mean)"),
+        paste0(label1, " (mean)")
+      ),
+      col = c("black", "red", "blue", "tan1"),
+      lty = c(1, 1, 1, 1), lwd = c(2, 2, 2, 4),
+      # cex=1.5,
+      cex = 2,
+      horiz = FALSE, bty = "n",
+      # title=paste0('at-basin'),
+      # title.col = 'purple',title.cex = 2
+    )
+
     # (b)
     #----------------------------------------- #
     ## -- water-year monthly distributions -- ##
     #----------------------------------------- #
-    years.months.weather <- format(dates.weather,'%Y-%m')
-    unique.years.months.weather <- format(ym(unique(years.months.weather)),'%m')
-    
-    dummy.long.years.vec <- long.years.vec+2000
-    years.months.sim <- paste0(dummy.long.years.vec,'-',long.months.vec)
-    unique.years.months.sim <- format(ym(unique(years.months.sim)),'%m')
-    
-    psite.obs.metric <- aggregate(mean.prcp.site,FUN=sum,by=list(years.months.weather))[,2]
-    psite.obs.metric2 <- aggregate(psite.obs.metric,FUN=median,by=list(unique.years.months.weather))[,2]
-    psite.obs.metric.q1th <- aggregate(psite.obs.metric,FUN=quantile,0.05,by=list(unique.years.months.weather))[,2]
-    psite.obs.metric.q2th <- aggregate(psite.obs.metric,FUN=quantile,0.95,by=list(unique.years.months.weather))[,2]
-    
-    psite.sim.metric <- aggregate(mean.prcp.site.sim,FUN=sum,by=list(years.months.sim))[,-1]
-    psite.sim.metric2 <- aggregate(psite.sim.metric,FUN=median,by=list(unique.years.months.sim))[,-1]
-    psite.sim.metric.q1th <- aggregate(psite.sim.metric,FUN=quantile,0.05,by=list(unique.years.months.sim))[,-1]
-    psite.sim.metric.q2th <- aggregate(psite.sim.metric,FUN=quantile,0.95,by=list(unique.years.months.sim))[,-1]
-    
-    ##reordering.dummy.aggre <- c(1,10,11,12,2,3,4,5,6,7,8,9) #stupidty of aggregate for sim
-    reordering.dummy.aggre <- c(1,5,6,7,8,9,10,11,12,2,3,4)
+    years.months.weather <- format(dates.weather, "%Y-%m")
+    unique.years.months.weather <- format(ym(unique(years.months.weather)), "%m")
+
+    dummy.long.years.vec <- long.years.vec + 2000
+    years.months.sim <- paste0(dummy.long.years.vec, "-", long.months.vec)
+    unique.years.months.sim <- format(ym(unique(years.months.sim)), "%m")
+
+    psite.obs.metric <- aggregate(mean.prcp.site, FUN = sum, by = list(years.months.weather))[, 2]
+    psite.obs.metric2 <- aggregate(psite.obs.metric, FUN = median, by = list(unique.years.months.weather))[, 2]
+    psite.obs.metric.q1th <- aggregate(psite.obs.metric, FUN = quantile, 0.05, by = list(unique.years.months.weather))[, 2]
+    psite.obs.metric.q2th <- aggregate(psite.obs.metric, FUN = quantile, 0.95, by = list(unique.years.months.weather))[, 2]
+
+    psite.sim.metric <- aggregate(mean.prcp.site.sim, FUN = sum, by = list(years.months.sim))[, -1]
+    psite.sim.metric2 <- aggregate(psite.sim.metric, FUN = median, by = list(unique.years.months.sim))[, -1]
+    psite.sim.metric.q1th <- aggregate(psite.sim.metric, FUN = quantile, 0.05, by = list(unique.years.months.sim))[, -1]
+    psite.sim.metric.q2th <- aggregate(psite.sim.metric, FUN = quantile, 0.95, by = list(unique.years.months.sim))[, -1]
+
+    ## reordering.dummy.aggre <- c(1,10,11,12,2,3,4,5,6,7,8,9) #stupidty of aggregate for sim
+    reordering.dummy.aggre <- c(1, 5, 6, 7, 8, 9, 10, 11, 12, 2, 3, 4)
     psite.sim.metric2 <- psite.sim.metric2[reordering.dummy.aggre]
     psite.sim.metric.q1th <- psite.sim.metric.q1th[reordering.dummy.aggre]
     psite.sim.metric.q2th <- psite.sim.metric.q2th[reordering.dummy.aggre]
-    
-    plot(months,psite.sim.metric2,
-         pch=4,col='black',cex=4.5,ylab='Precipitation [total]',frame=F,
-         font.main = 1,sub='',xlab='calendar month',
-         cex.lab=2,cex.axis=1.75,cex.main=2,
-         main='',
-         ylim=c(min(psite.sim.metric.q1th),max(psite.sim.metric.q2th)))
-    arrows(months,psite.obs.metric.q1th
-           ,months,psite.obs.metric.q2th,
-           length = 0,lwd=4,col=alpha('red',0.65))
-    
-    arrows(months,psite.sim.metric.q1th
-           ,months,psite.sim.metric.q2th,
-           length = 0,lwd=28,col=alpha('gray',0.5))
-    points(psite.obs.metric2,col="red",cex=3.5,pch=19)
-    legend("top", legend=c(paste0(label2," (5,median,95th)"),
-                           paste0(label1," (5,median,95th)")),
-           col=c("black", "red"), lty=c(1,0),cex=2,
-           pch=c(4,19),
-           horiz = F,bty='n',
-           # title=paste0('at-basin'),
-           # title.col = 'purple',title.cex = 2
+
+    plot(months, psite.sim.metric2,
+      pch = 4, col = "black", cex = 4.5, ylab = "Precipitation [total]", frame = F,
+      font.main = 1, sub = "", xlab = "calendar month",
+      cex.lab = 2, cex.axis = 1.75, cex.main = 2,
+      main = "",
+      ylim = c(min(psite.sim.metric.q1th), max(psite.sim.metric.q2th))
     )
-    
+    arrows(months, psite.obs.metric.q1th,
+      months, psite.obs.metric.q2th,
+      length = 0, lwd = 4, col = alpha("red", 0.65)
+    )
+
+    arrows(months, psite.sim.metric.q1th,
+      months, psite.sim.metric.q2th,
+      length = 0, lwd = 28, col = alpha("gray", 0.5)
+    )
+    points(psite.obs.metric2, col = "red", cex = 3.5, pch = 19)
+    legend("top",
+      legend = c(
+        paste0(label2, " (5,median,95th)"),
+        paste0(label1, " (5,median,95th)")
+      ),
+      col = c("black", "red"), lty = c(1, 0), cex = 2,
+      pch = c(4, 19),
+      horiz = F, bty = "n",
+      # title=paste0('at-basin'),
+      # title.col = 'purple',title.cex = 2
+    )
+
     dev.off()
   }
-  
-  
-  # Figure 4:
-  # 4) temperature cdf, mean, standard variation (yearly, year-to-year)
-  {
 
-    file.name.fig <- paste0("lines_tmean_mean_cdf_sd_",n.sites,".files_s",
-                            num.states,"_with_",num.iter,"_ens.png")
-    fname.fig <- paste0("./Figures/",file.name.fig)
-    ww.mom <- 14; hh.mom <- 14
-    png(fname.fig,width=ww.mom,height=hh.mom,units="in",res=300)
-    par(mfcol=c(2,2),mai=c(1,1,1,0.5))
-    
-    
+
+  #### Figure 4: ---------------------------------------------------------------
+  # 4) temperature cdf, mean, standard variation (yearly, year-to-year)
+  cat("\nScenario: ", scenario, "| 4) temperature cdf, mean, standard variation (yearly, year-to-year)\n\n")
+  {
+    file.name.fig <- paste0(
+      "lines_tmean_mean_cdf_sd_", n.sites, ".files_s",
+      num.states, "_with_", num.iter, "_ens.png"
+    )
+    fname.fig <- paste0(dir.to.figures, "/", file.name.fig)
+    ww.mom <- 14
+    hh.mom <- 14
+    png(fname.fig, width = ww.mom, height = hh.mom, units = "in", res = 300)
+    par(mfcol = c(2, 2), mai = c(1, 1, 1, 0.5))
+
+
     # (a)
     #------------------------------------------ #
     ## -- cdf of temperature distribution -- ##
     #------------------------------------------ #
-    annual.tmean <- stats::aggregate(mean.tmean.site,FUN=mean,by=list(wateryears.obs))[,2]
-    annual.tmean <- annual.tmean[2:(length(annual.tmean)-1)]   #drop first and last to only keep full water years
-    annual.tmean.boot.sort <- array(NA,c(length(annual.tmean),1000))
-    annual.tmean.sd <- array(NA,1000)
+    annual.tmean <- stats::aggregate(mean.tmean.site, FUN = mean, by = list(wateryears.obs))[, 2]
+    annual.tmean <- annual.tmean[2:(length(annual.tmean) - 1)] # drop first and last to only keep full water years
+    annual.tmean.boot.sort <- array(NA, c(length(annual.tmean), 1000))
+    annual.tmean.sd <- array(NA, 1000)
     for (i in 1:1000) {
-      annual.tmean.boot.sort[,i] <- base::sort(sample(annual.tmean,size=length(annual.tmean),replace=TRUE))
-      annual.tmean.sd[i] <- stats::sd(sample(annual.tmean,size=length(annual.tmean),replace=TRUE))
+      annual.tmean.boot.sort[, i] <- base::sort(sample(annual.tmean, size = length(annual.tmean), replace = TRUE))
+      annual.tmean.sd[i] <- stats::sd(sample(annual.tmean, size = length(annual.tmean), replace = TRUE))
     }
-    boot.95 <- apply(annual.tmean.boot.sort,1,FUN=quantile,.95)
-    boot.05 <- apply(annual.tmean.boot.sort,1,FUN=quantile,.05)
-    #get annual average temp from simulation
+    boot.95 <- apply(annual.tmean.boot.sort, 1, FUN = quantile, .95)
+    boot.05 <- apply(annual.tmean.boot.sort, 1, FUN = quantile, .05)
+    # get annual average temp from simulation
     tmean.basin.sim <- mean.tmean.site.sim
-    annual.tmean.sim <- stats::aggregate(tmean.basin.sim,FUN=mean,by=list(wateryears.sim),na.rm=T)[,2]
-    annual.tmean.sim <- annual.tmean.sim[2:(length(annual.tmean.sim)-1)] #drop first and last to only keep full water years
-    
-    
+    annual.tmean.sim <- stats::aggregate(tmean.basin.sim, FUN = mean, by = list(wateryears.sim), na.rm = T)[, 2]
+    annual.tmean.sim <- annual.tmean.sim[2:(length(annual.tmean.sim) - 1)] # drop first and last to only keep full water years
+
+
     y.hat <- annual.tmean
-    EP.hat <- (1:length(y.hat))/(length(y.hat)+1)
+    EP.hat <- (1:length(y.hat)) / (length(y.hat) + 1)
     y <- annual.tmean.sim
-    EP <- (1:length(y))/(length(y)+1)
-    plot(EP.hat,sort(y.hat),log="y",type='l',frame=F,
-         col="red",lwd=5,
-         xlab='Exceedance Probability',ylab='Temperature [WY]',
-         cex.axis=2,cex.main=4,cex.lab=2, font.main=1)
-    lines(EP,sort(y),lty=1, col='gray50',lwd=6)
-    polygon(x=c(EP.hat,rev(EP.hat)),y=c(boot.05,rev(boot.95)),
-            col=alpha('red',0.15),border=NA)
-    legend('topleft',c(paste0(label1,' (boot)'),paste0(label2)),
-           horiz = F,cex=1.75,title=paste0('at-basin'),
-           title.col = 'purple',title.cex = 2.5,
-           fill=c('red','black'),bty = 'n')
-    
+    EP <- (1:length(y)) / (length(y) + 1)
+    plot(EP.hat, sort(y.hat),
+      log = "y", type = "l", frame = F,
+      col = "red", lwd = 5,
+      xlab = "Exceedance Probability", ylab = "Temperature [WY]",
+      cex.axis = 2, cex.main = 4, cex.lab = 2, font.main = 1
+    )
+    lines(EP, sort(y), lty = 1, col = "gray50", lwd = 6)
+    polygon(
+      x = c(EP.hat, rev(EP.hat)), y = c(boot.05, rev(boot.95)),
+      col = alpha("red", 0.15), border = NA
+    )
+    legend("topleft", c(paste0(label1, " (boot)"), paste0(label2)),
+      horiz = F, cex = 1.75, title = paste0("at-basin"),
+      title.col = "purple", title.cex = 2.5,
+      fill = c("red", "black"), bty = "n"
+    )
+
     # (b)
     #----------------------------------------- #
     ## -- year-to-year SD of temperature -- ##
     #----------------------------------------- #
-    annual.tmean <- aggregate(mean.tmean.site,FUN=mean,by=list(wateryears.obs))[,2]
-    annual.tmean <- annual.tmean[2:(length(annual.tmean)-1)]   #drop first and last to only keep full water years
-    annual.tmean.sd <- array(NA,1000)
+    annual.tmean <- aggregate(mean.tmean.site, FUN = mean, by = list(wateryears.obs))[, 2]
+    annual.tmean <- annual.tmean[2:(length(annual.tmean) - 1)] # drop first and last to only keep full water years
+    annual.tmean.sd <- array(NA, 1000)
     for (i in 1:1000) {
-      annual.tmean.sd[i] <- sd(sample(annual.tmean,size=length(annual.tmean),replace=TRUE))
+      annual.tmean.sd[i] <- sd(sample(annual.tmean, size = length(annual.tmean), replace = TRUE))
     }
-    #get annual average tmean from simulation
+    # get annual average tmean from simulation
     tmean.basin.sim <- mean.tmean.site.sim
-    annual.tmean.sim <- aggregate(tmean.basin.sim,FUN=mean,by=list(wateryears.sim),na.rm=T)[,2]
-    annual.tmean.sim <- annual.tmean.sim[2:(length(annual.tmean.sim)-1)] #drop first and last to only keep full water years
-    
+    annual.tmean.sim <- aggregate(tmean.basin.sim, FUN = mean, by = list(wateryears.sim), na.rm = T)[, 2]
+    annual.tmean.sim <- annual.tmean.sim[2:(length(annual.tmean.sim) - 1)] # drop first and last to only keep full water years
+
     boxplot(annual.tmean.sd,
-            col=alpha('red',0.2),boxwex=0.5,boxcol=alpha('red',0.5),
-            outcol=alpha('red',0.5),outcex=1.15, outpch=21,medcol=alpha('red',0.5),
-            outbg=alpha('red',0.5),whiskcol=alpha('red',0.5),whisklty=1,staplecol=alpha('red',0.5),
-            frame=F,main='',
-            ylim = c(min(min(annual.tmean.sd),sd(annual.tmean),sd(annual.tmean.sim)),
-                     max(max(annual.tmean.sd),sd(annual.tmean),sd(annual.tmean.sim))),
-            xlab='',ylab='annual stdev [Average Temperature]',
-            cex.axis=2,cex.main=2.5,cex.lab=1.65, font.main=1)
-    points(sd(annual.tmean),col="red",pch=16,cex=3)
-    points(sd(annual.tmean.sim),col="black",pch=16,cex=3)
-    legend('topleft',c(paste0(label1,' (boot)'),paste0(label2)),
-           horiz = F,cex=2,title=paste0('at-basin'),
-           title.col = 'purple',title.cex = 2.5,
-           col=c('red','black'),pch=16,bty = 'n')
-    
-    
+      col = alpha("red", 0.2), boxwex = 0.5, boxcol = alpha("red", 0.5),
+      outcol = alpha("red", 0.5), outcex = 1.15, outpch = 21, medcol = alpha("red", 0.5),
+      outbg = alpha("red", 0.5), whiskcol = alpha("red", 0.5), whisklty = 1, staplecol = alpha("red", 0.5),
+      frame = F, main = "",
+      ylim = c(
+        min(min(annual.tmean.sd), sd(annual.tmean), sd(annual.tmean.sim)),
+        max(max(annual.tmean.sd), sd(annual.tmean), sd(annual.tmean.sim))
+      ),
+      xlab = "", ylab = "annual stdev [Average Temperature]",
+      cex.axis = 2, cex.main = 2.5, cex.lab = 1.65, font.main = 1
+    )
+    points(sd(annual.tmean), col = "red", pch = 16, cex = 3)
+    points(sd(annual.tmean.sim), col = "black", pch = 16, cex = 3)
+    legend("topleft", c(paste0(label1, " (boot)"), paste0(label2)),
+      horiz = F, cex = 2, title = paste0("at-basin"),
+      title.col = "purple", title.cex = 2.5,
+      col = c("red", "black"), pch = 16, bty = "n"
+    )
+
+
     # (c...)
     #--------------------------------------- #
     ## -- whiskers of long trace metrics -- ##
     #--------------------------------------- #
-    lst.annual.obs <- lst.annual.sim <- list()
-    lst.annual.obs[[1]] <- aggregate(tmean.site.data,FUN=mean,by=list(wateryears.obs))[,-1]
-    lst.annual.sim[[1]] <- aggregate(tmean.site.data.sim,FUN=mean,by=list(wateryears.sim))[,-1]
-    lst.annual.obs[[2]] <- aggregate(tmean.site.data,FUN=sd,by=list(wateryears.obs))[,-1]
-    lst.annual.sim[[2]] <- aggregate(tmean.site.data.sim,FUN=sd,by=list(wateryears.sim))[,-1]
-    
-    labs.metrics <- c('mean','stdev')
-    
-    for (k in 1:length(labs.metrics)){
+    lst.annual.obs <- lst.annual.sim <- vector("list", length(labs.metrics))
+    lst.annual.obs[[1]] <- aggregate(tmean.site.data, FUN = mean, by = list(wateryears.obs))[, -1]
+    lst.annual.sim[[1]] <- aggregate(tmean.site.data.sim, FUN = mean, by = list(wateryears.sim))[, -1]
+    lst.annual.obs[[2]] <- aggregate(tmean.site.data, FUN = sd, by = list(wateryears.obs))[, -1]
+    lst.annual.sim[[2]] <- aggregate(tmean.site.data.sim, FUN = sd, by = list(wateryears.sim))[, -1]
+
+    # labs.metrics <- c("mean", "stdev")
+
+    for (k in 1:length(labs.metrics)) {
       annual.obs <- lst.annual.obs[[k]]
       annual.sim <- lst.annual.sim[[k]]
       my.sim.y <- annual.sim
       my.obs.y <- annual.obs
-      
-      my1.x0 <- apply(my.sim.y,2,FUN=median)
-      my1.y0 <- apply(my.obs.y,2,FUN=quantile,0.05)
-      my1.y1 <- apply(my.obs.y,2,FUN=quantile,0.95)
-      
-      my2.x0 <- my2.x1 <- apply(my.obs.y,2,FUN=median)
-      my2.y0 <- apply(my.sim.y,2,FUN=quantile,0.05)
-      my2.y1 <- apply(my.sim.y,2,FUN=quantile,0.95)
-      x_y_lim <- c(min(c(my1.y0,my2.y0)),max(c(my1.y1,my2.y1)))
-      
-      plot(my1.x0, my2.x0, xlim=x_y_lim, ylim=x_y_lim,
-           pch=1, cex=2.25, frame=T,col=NULL,
-           xlab='',ylab='',
-           cex.axis=2,
-           main=paste0(labs.metrics[k]),sub='|5th, median, 95th|',col.sub=alpha('blue',0.5),
-           cex.lab=2, cex.main=3, font.main=1,cex.sub=1.75)
-      mtext(paste0(label2),1,col='gray60',line=2.5, cex=1.75)
-      mtext(label1,2,col='red',line=2.5, cex=1.75)
-      arrows(x0=my2.y0,
-             y0=my2.x0, x1=my2.y1, y1=my2.x0, code=3, angle=90, length=0.025, col=alpha("gray40",0.75), lwd=0.5)
-      arrows(x0=my1.x0,
-             y0=my1.y0, x1=my1.x0, y1=my1.y1, code=3, angle=90, length=0.025, col=alpha("red",0.75), lwd=0.5)
-      abline(0,1,lwd=1.5,lty=2)
-      points(my1.x0, my2.x0, xlim=x_y_lim, ylim=x_y_lim, pch=19, 
-             cex=1.5,col=alpha("gray40",0.65))
-      legend("topleft",legend=c(NA) ,title=paste0('at-site'),pch=19,cex=2.5,
-             col='gray40',bty = 'n',title.col = 'purple',
-             horiz = FALSE,inset=0.0)
+
+      my1.x0 <- apply(my.sim.y, 2, FUN = median)
+      my1.y0 <- apply(my.obs.y, 2, FUN = quantile, 0.05)
+      my1.y1 <- apply(my.obs.y, 2, FUN = quantile, 0.95)
+
+      my2.x0 <- my2.x1 <- apply(my.obs.y, 2, FUN = median)
+      my2.y0 <- apply(my.sim.y, 2, FUN = quantile, 0.05)
+      my2.y1 <- apply(my.sim.y, 2, FUN = quantile, 0.95)
+      x_y_lim <- c(min(c(my1.y0, my2.y0)), max(c(my1.y1, my2.y1)))
+
+      plot(my1.x0, my2.x0,
+        xlim = x_y_lim, ylim = x_y_lim,
+        pch = 1, cex = 2.25, frame = T, col = NULL,
+        xlab = "", ylab = "",
+        cex.axis = 2,
+        main = paste0(labs.metrics[k]), sub = "|5th, median, 95th|", col.sub = alpha("blue", 0.5),
+        cex.lab = 2, cex.main = 3, font.main = 1, cex.sub = 1.75
+      )
+      mtext(paste0(label2), 1, col = "gray60", line = 2.5, cex = 1.75)
+      mtext(label1, 2, col = "red", line = 2.5, cex = 1.75)
+      arrows(
+        x0 = my2.y0,
+        y0 = my2.x0, x1 = my2.y1, y1 = my2.x0, code = 3, angle = 90, length = 0.025, col = alpha("gray40", 0.75), lwd = 0.5
+      )
+      arrows(
+        x0 = my1.x0,
+        y0 = my1.y0, x1 = my1.x0, y1 = my1.y1, code = 3, angle = 90, length = 0.025, col = alpha("red", 0.75), lwd = 0.5
+      )
+      abline(0, 1, lwd = 1.5, lty = 2)
+      points(my1.x0, my2.x0,
+        xlim = x_y_lim, ylim = x_y_lim, pch = 19,
+        cex = 1.5, col = alpha("gray40", 0.65)
+      )
+      legend("topleft",
+        legend = c(NA), title = paste0("at-site"), pch = 19, cex = 2.5,
+        col = "gray40", bty = "n", title.col = "purple",
+        horiz = FALSE, inset = 0.0
+      )
     }
-    
+
     dev.off()
   }
-  
-  
-  # Figure 5:
+
+
+  #### Figure 5: ---------------------------------------------------------------
   # 5) heat and cold waves/stress temperature
+  cat("\nScenario: ", scenario, "| 5) heat and cold waves/stress temperature\n\n")
   {
-    temp.specific.diagnostics <- function(temp.mean,temp.max,temp.min,
-                                          my.range=NULL,mc.cores=1)
-    {
-      
+    temp.specific.diagnostics <- function(temp.mean, temp.max, temp.min,
+                                          my.range = NULL, mc.cores = 1) {
       # temp.min <- temp.max <- temp.mean
-      #This function will calculate a series of specific diagnostic statistics for temp, which is a list of independent temp vectors 
+      # This function will calculate a series of specific diagnostic statistics for temp, which is a list of independent temp vectors
       #
-      #Arguments:
-      #temp = a list of temperature (min,max) time series for each site (i.e., a list of temperature matrices), with list dimension d
-      
+      # Arguments:
+      # temp = a list of temperature (min,max) time series for each site (i.e., a list of temperature matrices), with list dimension d
+
       # Heatwave definition: Three or more consecutive days over 90 degrees F. (based on the state of MA definition)
       # Coldwave definition: Ten or more consecutive days below 20 degrees F. (User-specific criteria)
       hw.temp <- 32.22 # 32.22 deg. C  == 90 deg. F
       cw.temp <- -7 # -7 deg. C  == 20 deg. F
       min.days.hw <- 3
       min.days.cw <- 5 # this was 10 for MA project
-      
-      temp.extreme.high.thresh <- 30    # trace extreme high temperature == 86 F
-      temp.extreme.low.thresh <- 0    # trace extreme low temperature == 32 F
+
+      temp.extreme.high.thresh <- 30 # trace extreme high temperature == 86 F
+      temp.extreme.low.thresh <- 0 # trace extreme low temperature == 32 F
       ma.options.rolling <- c(3) # for 3-day moving average
-      
-      rep.row<-function(x,n){
-        matrix(rep(x,each=n),nrow=n)
+
+      rep.row <- function(x, n) {
+        matrix(rep(x, each = n), nrow = n)
       }
-      
+
       d <- length(temp.min)
       n.sites <- dim(temp.min[[1]])[2]
       n.days <- dim(temp.min[[1]])[1]
-      stat.names <- c('number.heatwaves','mean.heatwaves.duration','max.heatwaves.duration',
-                      'number.coldwaves','mean.coldwaves.duration','max.coldwaves.duration',
-                      'number.heatstress','number.coldstress',
-                      'mean.intensity.heatwaves','mean.intensity.coldwaves',
-                      'max.intensity.heatwaves','max.intensity.coldwaves')
+      stat.names <- c(
+        "number.heatwaves", "mean.heatwaves.duration", "max.heatwaves.duration",
+        "number.coldwaves", "mean.coldwaves.duration", "max.coldwaves.duration",
+        "number.heatstress", "number.coldstress",
+        "mean.intensity.heatwaves", "mean.intensity.coldwaves",
+        "max.intensity.heatwaves", "max.intensity.coldwaves"
+      )
       n.stats <- length(stat.names)
-      if(is.null(my.range)) {my.range <- 1:dim(temp.min[[1]])[1]}
-      
-      #calculate at-site statistics  
-      stat.list <- mclapply(X=1:d,mc.preschedule=TRUE,mc.cores=mc.cores,FUN=function(i){  
-        
-        my.stats <- array(0,c(n.sites,n.stats))
-        
-        
-        if (sum(is.infinite(temp.min[[i]]))>0){
-          idx.dummy <- which(is.infinite(temp.min[[i]]),arr.ind = T)
-          temp.min[[i]][idx.dummy[,1],idx.dummy[,2]] <- NA} # checkpoints to not have "Inf" before going ahead
-        if (sum(is.infinite(temp.max[[i]]))>0){
-          idx.dummy <- which(is.infinite(temp.max[[i]]),arr.ind = T)
-          temp.max[[i]][idx.dummy[,1],idx.dummy[,2]] <- NA} # checkpoints to not have "Inf" before going ahead
-        
+      if (is.null(my.range)) {
+        my.range <- 1:dim(temp.min[[1]])[1]
+      }
+
+      # calculate at-site statistics
+      stat.list <- mclapply(X = 1:d, mc.preschedule = TRUE, mc.cores = mc.cores, FUN = function(i) {
+        my.stats <- array(0, c(n.sites, n.stats))
+
+
+        if (sum(is.infinite(temp.min[[i]])) > 0) {
+          idx.dummy <- which(is.infinite(temp.min[[i]]), arr.ind = T)
+          temp.min[[i]][idx.dummy[, 1], idx.dummy[, 2]] <- NA
+        } # checkpoints to not have "Inf" before going ahead
+        if (sum(is.infinite(temp.max[[i]])) > 0) {
+          idx.dummy <- which(is.infinite(temp.max[[i]]), arr.ind = T)
+          temp.max[[i]][idx.dummy[, 1], idx.dummy[, 2]] <- NA
+        } # checkpoints to not have "Inf" before going ahead
+
         # cur.temp.min <- temp.min[[i]][my.range,]
         # cur.temp.max <- temp.max[[i]][my.range,]
         # cur.temp <- (cur.temp.min+cur.temp.max)/2
-        
+
         # Number of heatwaves, mean length, max values
-        cur.temp <- temp.max[[i]][my.range,]
-        
-        bin.hw <- (cur.temp>hw.temp)*1
-        bin.hw.cur.temp <- cur.temp*bin.hw
-        if (sum(bin.hw>0)>0){
+        cur.temp <- temp.max[[i]][my.range, ]
+
+        bin.hw <- (cur.temp > hw.temp) * 1
+        bin.hw.cur.temp <- cur.temp * bin.hw
+        if (sum(bin.hw > 0) > 0) {
           bin.cur.temp <- bin.hw.cur.temp
-          mat.my.stats <- sapply(1:n.sites,function(x){
-            my.intensity <- array(0,c(5,1))
-            obs_time <- data.frame(cbind(bin.cur.temp[,x],my.range))
-            colnames(obs_time) <- c('obs','time')
-            if(!sum(obs_time$obs)==0){
-              
-              clust.obs_time_durations <- try(clust(obs_time,u=0,
-                                                    tim.cond=0,clust.max=FALSE,
-                                                    plot=FALSE))
+          mat.my.stats <- sapply(1:n.sites, function(x) {
+            my.intensity <- array(0, c(5, 1))
+            obs_time <- data.frame(cbind(bin.cur.temp[, x], my.range))
+            colnames(obs_time) <- c("obs", "time")
+            if (!sum(obs_time$obs) == 0) {
+              clust.obs_time_durations <- try(clust(obs_time,
+                u = 0,
+                tim.cond = 0, clust.max = FALSE,
+                plot = FALSE
+              ))
               site.declust <- c()
-              site.declust$intensity <- sapply(1:length(clust.obs_time_durations),function(y){
-                return(mean(clust.obs_time_durations[[y]][2,])-hw.temp)})
-              site.declust$maxintensity <- sapply(1:length(clust.obs_time_durations),function(y){
-                return(max(clust.obs_time_durations[[y]][2,])-hw.temp)})
-              site.declust$durations <- sapply(1:length(clust.obs_time_durations),function(y){
-                return(length(clust.obs_time_durations[[y]][2,]))})
-              if (sum(site.declust$durations>=min.days.hw & site.declust$intensity>=0)>0){
-                
-                my.intensity[1,1] <- mean(site.declust$intensity[site.declust$durations>=min.days.hw & site.declust$intensity>=0])
-                my.intensity[2,1] <- mean(site.declust$maxintensity[site.declust$durations>=min.days.hw & site.declust$intensity>=0])
-                my.intensity[3,1] <- mean(site.declust$durations[site.declust$durations>=min.days.hw & site.declust$intensity>=0])
-                my.intensity[4,1] <- max(site.declust$durations[site.declust$durations>=min.days.hw & site.declust$intensity>=0])
-                my.intensity[5,1] <- sum(site.declust$durations>=min.days.hw & site.declust$intensity>=0)
-                
+              site.declust$intensity <- sapply(1:length(clust.obs_time_durations), function(y) {
+                return(mean(clust.obs_time_durations[[y]][2, ]) - hw.temp)
+              })
+              site.declust$maxintensity <- sapply(1:length(clust.obs_time_durations), function(y) {
+                return(max(clust.obs_time_durations[[y]][2, ]) - hw.temp)
+              })
+              site.declust$durations <- sapply(1:length(clust.obs_time_durations), function(y) {
+                return(length(clust.obs_time_durations[[y]][2, ]))
+              })
+              if (sum(site.declust$durations >= min.days.hw & site.declust$intensity >= 0) > 0) {
+                my.intensity[1, 1] <- mean(site.declust$intensity[site.declust$durations >= min.days.hw & site.declust$intensity >= 0])
+                my.intensity[2, 1] <- mean(site.declust$maxintensity[site.declust$durations >= min.days.hw & site.declust$intensity >= 0])
+                my.intensity[3, 1] <- mean(site.declust$durations[site.declust$durations >= min.days.hw & site.declust$intensity >= 0])
+                my.intensity[4, 1] <- max(site.declust$durations[site.declust$durations >= min.days.hw & site.declust$intensity >= 0])
+                my.intensity[5, 1] <- sum(site.declust$durations >= min.days.hw & site.declust$intensity >= 0)
               }
             }
             return(my.intensity)
           })
-          my.stats[,1] <- mat.my.stats[5,] # freq
-          my.stats[,2] <- mat.my.stats[3,] # mean dur
-          my.stats[,3] <- mat.my.stats[4,] # max dur
-          my.stats[,9] <- mat.my.stats[1,] # mean intensity
-          my.stats[,11] <- mat.my.stats[2,] # max intensity
+          my.stats[, 1] <- mat.my.stats[5, ] # freq
+          my.stats[, 2] <- mat.my.stats[3, ] # mean dur
+          my.stats[, 3] <- mat.my.stats[4, ] # max dur
+          my.stats[, 9] <- mat.my.stats[1, ] # mean intensity
+          my.stats[, 11] <- mat.my.stats[2, ] # max intensity
         }
-        
+
         # Number of coldwaves, mean length, max values
-        cur.temp <- temp.min[[i]][my.range,]
-        
-        bin.cw <- (cur.temp<cw.temp)*1
-        bin.cw.cur.temp <- cur.temp*bin.cw
-        if (sum(bin.cw>0)>0){
+        cur.temp <- temp.min[[i]][my.range, ]
+
+        bin.cw <- (cur.temp < cw.temp) * 1
+        bin.cw.cur.temp <- cur.temp * bin.cw
+        if (sum(bin.cw > 0) > 0) {
           bin.cur.temp <- bin.cw.cur.temp
-          mat.my.stats <- sapply(1:n.sites,function(x){
-            my.intensity <- array(0,c(5,1))
-            obs_time <- data.frame(cbind(-bin.cur.temp[,x],my.range)) # x -1 for POT
-            colnames(obs_time) <- c('obs','time')
-            if(!sum(obs_time$obs)==0){
-              
-              clust.obs_time_durations <- try(clust(obs_time,u=0,
-                                                    tim.cond=0,clust.max=FALSE,
-                                                    plot=FALSE))
+          mat.my.stats <- sapply(1:n.sites, function(x) {
+            my.intensity <- array(0, c(5, 1))
+            obs_time <- data.frame(cbind(-bin.cur.temp[, x], my.range)) # x -1 for POT
+            colnames(obs_time) <- c("obs", "time")
+            if (!sum(obs_time$obs) == 0) {
+              clust.obs_time_durations <- try(clust(obs_time,
+                u = 0,
+                tim.cond = 0, clust.max = FALSE,
+                plot = FALSE
+              ))
               site.declust <- c()
-              site.declust$intensity <- sapply(1:length(clust.obs_time_durations),function(y){
-                return(mean(clust.obs_time_durations[[y]][2,])-abs(cw.temp))})
-              site.declust$maxintensity <- sapply(1:length(clust.obs_time_durations),function(y){
-                return(max(clust.obs_time_durations[[y]][2,])-abs(cw.temp))})
-              site.declust$durations <- sapply(1:length(clust.obs_time_durations),function(y){
-                return(length(clust.obs_time_durations[[y]][2,]))})
-              if (sum(site.declust$durations>=min.days.cw & site.declust$intensity>=0)>0){
-                my.intensity[1,1] <- -mean(site.declust$intensity[site.declust$durations>=min.days.cw & site.declust$intensity>=0]) # x -1 for POT
-                my.intensity[2,1] <- -mean(site.declust$maxintensity[site.declust$durations>=min.days.cw & site.declust$intensity>=0]) # x -1 for POT
-                my.intensity[3,1] <- mean(site.declust$durations[site.declust$durations>=min.days.cw & site.declust$intensity>=0])
-                my.intensity[4,1] <- max(site.declust$durations[site.declust$durations>=min.days.cw & site.declust$intensity>=0])
-                my.intensity[5,1] <- sum(site.declust$durations>=min.days.cw & site.declust$intensity>=0)
-                
+              site.declust$intensity <- sapply(1:length(clust.obs_time_durations), function(y) {
+                return(mean(clust.obs_time_durations[[y]][2, ]) - abs(cw.temp))
+              })
+              site.declust$maxintensity <- sapply(1:length(clust.obs_time_durations), function(y) {
+                return(max(clust.obs_time_durations[[y]][2, ]) - abs(cw.temp))
+              })
+              site.declust$durations <- sapply(1:length(clust.obs_time_durations), function(y) {
+                return(length(clust.obs_time_durations[[y]][2, ]))
+              })
+              if (sum(site.declust$durations >= min.days.cw & site.declust$intensity >= 0) > 0) {
+                my.intensity[1, 1] <- -mean(site.declust$intensity[site.declust$durations >= min.days.cw & site.declust$intensity >= 0]) # x -1 for POT
+                my.intensity[2, 1] <- -mean(site.declust$maxintensity[site.declust$durations >= min.days.cw & site.declust$intensity >= 0]) # x -1 for POT
+                my.intensity[3, 1] <- mean(site.declust$durations[site.declust$durations >= min.days.cw & site.declust$intensity >= 0])
+                my.intensity[4, 1] <- max(site.declust$durations[site.declust$durations >= min.days.cw & site.declust$intensity >= 0])
+                my.intensity[5, 1] <- sum(site.declust$durations >= min.days.cw & site.declust$intensity >= 0)
               }
             }
             return(my.intensity)
           })
-          my.stats[,4] <- mat.my.stats[5,] # freq
-          my.stats[,5] <- mat.my.stats[3,] # mean dur
-          my.stats[,6] <- mat.my.stats[4,] # max dur
-          my.stats[,10] <- mat.my.stats[1,] # mean intensity 
-          my.stats[,12] <- mat.my.stats[2,] # max intensity
+          my.stats[, 4] <- mat.my.stats[5, ] # freq
+          my.stats[, 5] <- mat.my.stats[3, ] # mean dur
+          my.stats[, 6] <- mat.my.stats[4, ] # max dur
+          my.stats[, 10] <- mat.my.stats[1, ] # mean intensity
+          my.stats[, 12] <- mat.my.stats[2, ] # max intensity
         }
-        
-        
+
+
         # cur.temp.min <- temp.min[[i]][my.range,]
         # cur.temp.max <- temp.max[[i]][my.range,]
         # cur.temp <- (cur.temp.min+cur.temp.max)/2
-        
-        #heatstress
-        cur.temp <- temp.max[[i]][my.range,]
-        #extreme.high.temp.val <- apply(cur.temp,2,FUN=quantile,temp.extreme.high.thresh,na.rm=T)
-        mat.extreme.high.temp.val <- rep.row(temp.extreme.high.thresh,n.days-ma.options.rolling[1]+1)
-        y1 <- apply(cur.temp,2,function(x){rollapply(data=x, FUN = mean, width = ma.options.rolling[1])})
-        
-        #coldstress
-        cur.temp <- temp.min[[i]][my.range,]
-        #extreme.low.temp.val <- apply(cur.temp,2,FUN=quantile,temp.extreme.low.thresh,na.rm=T)
-        mat.extreme.low.temp.val <- rep.row(temp.extreme.low.thresh,n.days-ma.options.rolling[1]+1)
-        y2 <- apply(cur.temp,2,function(x){rollapply(data=x, FUN = mean, width = ma.options.rolling[1])})
-        
-        #my.stats[,7] <- max(c(0,sum(y>mat.extreme.high.temp.val)))
-        my.stats[,7] <- apply(y1,2,function(x){sum(x>mat.extreme.high.temp.val)})
-        
-        #my.stats[,8] <- max(c(0,sum(y<mat.extreme.low.temp.val)))
-        my.stats[,8] <- apply(y2,2,function(x){sum(x<mat.extreme.low.temp.val)})
-        
+
+        # heatstress
+        cur.temp <- temp.max[[i]][my.range, ]
+        # extreme.high.temp.val <- apply(cur.temp,2,FUN=quantile,temp.extreme.high.thresh,na.rm=T)
+        mat.extreme.high.temp.val <- rep.row(temp.extreme.high.thresh, n.days - ma.options.rolling[1] + 1)
+        y1 <- apply(cur.temp, 2, function(x) {
+          rollapply(data = x, FUN = mean, width = ma.options.rolling[1])
+        })
+
+        # coldstress
+        cur.temp <- temp.min[[i]][my.range, ]
+        # extreme.low.temp.val <- apply(cur.temp,2,FUN=quantile,temp.extreme.low.thresh,na.rm=T)
+        mat.extreme.low.temp.val <- rep.row(temp.extreme.low.thresh, n.days - ma.options.rolling[1] + 1)
+        y2 <- apply(cur.temp, 2, function(x) {
+          rollapply(data = x, FUN = mean, width = ma.options.rolling[1])
+        })
+
+        # my.stats[,7] <- max(c(0,sum(y>mat.extreme.high.temp.val)))
+        my.stats[, 7] <- apply(y1, 2, function(x) {
+          sum(x > mat.extreme.high.temp.val)
+        })
+
+        # my.stats[,8] <- max(c(0,sum(y<mat.extreme.low.temp.val)))
+        my.stats[, 8] <- apply(y2, 2, function(x) {
+          sum(x < mat.extreme.low.temp.val)
+        })
+
         return(my.stats)
       })
       my.stats <- unlist(stat.list)
-      dim(my.stats) <- c(n.sites,n.stats,d)    
-      dimnames(my.stats)[[2]] <- stat.names    
-      
+      dim(my.stats) <- c(n.sites, n.stats, d)
+      dimnames(my.stats)[[2]] <- stat.names
+
       return(my.stats)
-      
     }
-    
-    temp.specific.obs <- temp.specific.diagnostics(list(tmean.site.data),
-                                                   list(tmax.site.data),
-                                                   list(tmin.site.data))
-    temp.specific.obs <- data.frame(temp.specific.obs[,,1])
+
+    temp.specific.obs <- temp.specific.diagnostics(
+      list(tmean.site.data),
+      list(tmax.site.data),
+      list(tmin.site.data)
+    )
+    temp.specific.obs <- data.frame(temp.specific.obs[, , 1])
     # converting to per year metrics:
-    temp.specific.obs[,c(1,4,7,8)] <- temp.specific.obs[,c(1,4,7,8)]/length(unique(years.weather))
-    temp.specific.sim <- temp.specific.diagnostics(list(tmean.site.data.sim),
-                                                   list(tmax.site.data.sim),
-                                                   list(tmin.site.data.sim))
-    temp.specific.sim <- data.frame(temp.specific.sim[,,1])
+    temp.specific.obs[, c(1, 4, 7, 8)] <- temp.specific.obs[, c(1, 4, 7, 8)] / length(unique(years.weather))
+    temp.specific.sim <- temp.specific.diagnostics(
+      list(tmean.site.data.sim),
+      list(tmax.site.data.sim),
+      list(tmin.site.data.sim)
+    )
+    temp.specific.sim <- data.frame(temp.specific.sim[, , 1])
     # converting to per year metrics:
-    temp.specific.sim[,c(1,4,7,8)] <- temp.specific.sim[,c(1,4,7,8)]/total.num.yrs
-    
+    temp.specific.sim[, c(1, 4, 7, 8)] <- temp.specific.sim[, c(1, 4, 7, 8)] / total.num.yrs
+
     temp.specific.obs[is.infinite(as.matrix(temp.specific.obs))] <- NA
     temp.specific.sim[is.infinite(as.matrix(temp.specific.sim))] <- NA
-    
+
     # label1 <- 'Obs [1948-2018]'
     # label2 <- 'Sim (WGEN: baseline)'
-    labs.metrics <- c('Heat Wave Frequency','Heat Wave Duration (mean)','Heat Wave Duration (max)',
-                      'Cold Wave Frequency','Cold Wave Duration (mean)','Cold Wave Duration (max)',
-                      'Heat Stress Frequency','Cold Stress Frequency',
-                      'Heat Wave Intensity (mean)','Cold Wave Intensity (mean)',
-                      'Heat Wave Intensity (max)','Cold Wave Intensity (max)')
-    unit.metric <- c('#','(days)','(days)',
-                     '#','(days)','(days)',
-                     '#','#',
-                     '(above-threshold, C)','(below-threshold, C)',
-                     '(above-threshold, C)','(below-threshold, C)')
-    
-    file.name.fig <- paste0("scatters_tmax_tmin_heat.cold.specific_",n.sites,".files_s",
-                            num.states,"_with_",num.iter,"_ens.png")
-    fname.fig <- paste0("./Figures/",file.name.fig)
-    ww.mom <- 18; hh.mom <- 10
-    png(fname.fig,width=ww.mom,height=hh.mom,units="in",res=300)
-    par(mfrow=c(2,4),mar=c(5.1, 6.1, 4.1, 2.1))
-    
-    for (k in c(2,3,9,11,5,6,10,12)){
-      my1.x0 <- temp.specific.obs[,k]
-      my2.x0 <- temp.specific.sim[,k]
-      x_y_lim <- c(min(c(my1.x0,my2.x0),na.rm=T),
-                   max(c(my1.x0,my2.x0),na.rm=T))
-      
-      plot(my2.x0,my1.x0, xlim=x_y_lim, ylim=x_y_lim,
-           pch=1, cex=2, frame=F,col=NULL,
-           xlab='',ylab='',
-           cex.axis=1.5,
-           main=paste0(labs.metrics[k]),sub=paste0(unit.metric[k]),col.sub=alpha('blue',0.5),
-           cex.lab=1.25, cex.main=2, font.main=1,cex.sub=1.5)
-      mtext(paste0(label2),1,col='gray10',line=2.35)
-      mtext(paste0(label1),2,col='red',line=2.35)
-      
-      abline(a=0,b=1, col='gray75',lwd=1.5, lty=2)
-      points(my2.x0,my1.x0, xlim=x_y_lim, ylim=x_y_lim, pch=16, 
-             cex=2.5,col=alpha("gray40",0.65))
-      legend("topleft",pch=16,
-             col='gray30',
-             horiz = FALSE,inset=0.01,text.col='purple',
-             cex=1.5,legend=paste0('at-site'),
-             title.col = 'black',title.cex = 2.5,bty = 'n')
+    labs.metrics <- c(
+      "Heat Wave Frequency", "Heat Wave Duration (mean)", "Heat Wave Duration (max)",
+      "Cold Wave Frequency", "Cold Wave Duration (mean)", "Cold Wave Duration (max)",
+      "Heat Stress Frequency", "Cold Stress Frequency",
+      "Heat Wave Intensity (mean)", "Cold Wave Intensity (mean)",
+      "Heat Wave Intensity (max)", "Cold Wave Intensity (max)"
+    )
+    unit.metric <- c(
+      "#", "(days)", "(days)",
+      "#", "(days)", "(days)",
+      "#", "#",
+      "(above-threshold, C)", "(below-threshold, C)",
+      "(above-threshold, C)", "(below-threshold, C)"
+    )
+
+    file.name.fig <- paste0(
+      "scatters_tmax_tmin_heat.cold.specific_", n.sites, ".files_s",
+      num.states, "_with_", num.iter, "_ens.png"
+    )
+    fname.fig <- paste0(dir.to.figures, "/", file.name.fig)
+    ww.mom <- 18
+    hh.mom <- 10
+    png(fname.fig, width = ww.mom, height = hh.mom, units = "in", res = 300)
+    par(mfrow = c(2, 4), mar = c(5.1, 6.1, 4.1, 2.1))
+
+    for (k in c(2, 3, 9, 11, 5, 6, 10, 12)) {
+      my1.x0 <- temp.specific.obs[, k]
+      my2.x0 <- temp.specific.sim[, k]
+      x_y_lim <- c(
+        min(c(my1.x0, my2.x0), na.rm = T),
+        max(c(my1.x0, my2.x0), na.rm = T)
+      )
+
+      plot(my2.x0, my1.x0,
+        xlim = x_y_lim, ylim = x_y_lim,
+        pch = 1, cex = 2, frame = F, col = NULL,
+        xlab = "", ylab = "",
+        cex.axis = 1.5,
+        main = paste0(labs.metrics[k]), sub = paste0(unit.metric[k]), col.sub = alpha("blue", 0.5),
+        cex.lab = 1.25, cex.main = 2, font.main = 1, cex.sub = 1.5
+      )
+      mtext(paste0(label2), 1, col = "gray10", line = 2.35)
+      mtext(paste0(label1), 2, col = "red", line = 2.35)
+
+      abline(a = 0, b = 1, col = "gray75", lwd = 1.5, lty = 2)
+      points(my2.x0, my1.x0,
+        xlim = x_y_lim, ylim = x_y_lim, pch = 16,
+        cex = 2.5, col = alpha("gray40", 0.65)
+      )
+      legend("topleft",
+        pch = 16,
+        col = "gray30",
+        horiz = FALSE, inset = 0.01, text.col = "purple",
+        cex = 1.5, legend = paste0("at-site"),
+        title.col = "black", title.cex = 2.5, bty = "n"
+      )
     }
     dev.off()
   }
-  
-  
-  # Figure 6:
-  # 6) precipitation minima, dry-spells, drought stats
-  {
 
-    file.name.fig <- paste0("hist_prcp.n.year.droughts_minima_dry.spells_",n.sites,".files_s",
-                            num.states,"_with_",num.iter,"_ens.png")
-    fname.fig <- paste0("./Figures/",file.name.fig)
-    ww.mom <- 26; hh.mom <- 14
-    png(fname.fig,width=ww.mom,height=hh.mom,units="in",res=300)
-    par(mfcol=c(2,4),mai=c(0.75,1,1,0.5))
-    
+
+  #### Figure 6: ---------------------------------------------------------------
+  # 6) precipitation minima, dry-spells, drought stats
+  cat("\nScenario: ", scenario, "| 6) precipitation minima, dry-spells, drought stats\n\n")
+  {
+    file.name.fig <- paste0(
+      "hist_prcp.n.year.droughts_minima_dry.spells_", n.sites, ".files_s",
+      num.states, "_with_", num.iter, "_ens.png"
+    )
+    fname.fig <- paste0(dir.to.figures, "/", file.name.fig)
+    ww.mom <- 26
+    hh.mom <- 14
+    png(fname.fig, width = ww.mom, height = hh.mom, units = "in", res = 300)
+    par(mfcol = c(2, 4), mai = c(0.75, 1, 1, 0.5))
+
     # (a)
     #----------------------------------------- #
     ## -- worst/long-term droughts -- ##
     #----------------------------------------- #
-    prcp.min.extreme.diagnostics <- function(prcp,my.range=NULL,mc.cores=1) {
+    prcp.min.extreme.diagnostics <- function(prcp, my.range = NULL, mc.cores = 1) {
       nyears <- 10
-      
+
       d <- length(prcp)
       n.sites <- dim(prcp[[1]])[2]
       # ma.options.rolling <- seq(1,nyears)*365 # n-day moving averages
-      ma.options.rolling <- seq(1,nyears) # n-year moving averages
-      stat.names2 <- paste0(seq(1,nyears),'.year.min')
-      #calculate at-site statistics: min
+      ma.options.rolling <- seq(1, nyears) # n-year moving averages
+      stat.names2 <- paste0(seq(1, nyears), ".year.min")
+      # calculate at-site statistics: min
       n.stats <- length(stat.names2)
-      
-      
-      if(is.null(my.range)) {my.range <- 1:dim(prcp[[1]])[1]}
-      stat.list2 <- mclapply(X=1:d,mc.preschedule=TRUE,mc.cores=mc.cores,FUN=function(i){  
-        my.stats2 <- array(NA,c(n.sites,n.stats))
-        cur.prcp <- as.matrix(prcp[[i]][my.range,])
-        if (sum(is.infinite(cur.prcp))>0){
-          idx.dummy <- which(is.infinite(cur.prcp),arr.ind = T)
-          #cur.prcp[idx.dummy[,1],idx.dummy[,2]] <-.Machine$double.eps # checkpoints to not have "Inf" before going ahead
-          cur.prcp[idx.dummy[,1],idx.dummy[,2]] <- NA
+
+
+      if (is.null(my.range)) {
+        my.range <- 1:dim(prcp[[1]])[1]
+      }
+      stat.list2 <- mclapply(X = 1:d, mc.preschedule = TRUE, mc.cores = mc.cores, FUN = function(i) {
+        my.stats2 <- array(NA, c(n.sites, n.stats))
+        cur.prcp <- as.matrix(prcp[[i]][my.range, ])
+        if (sum(is.infinite(cur.prcp)) > 0) {
+          idx.dummy <- which(is.infinite(cur.prcp), arr.ind = T)
+          # cur.prcp[idx.dummy[,1],idx.dummy[,2]] <-.Machine$double.eps # checkpoints to not have "Inf" before going ahead
+          cur.prcp[idx.dummy[, 1], idx.dummy[, 2]] <- NA
         }
-        
+
         for (s in 1:n.stats) {
-          my.stats2[,s] <- apply(cur.prcp,2,function(x){min(rollapply(data=x, FUN = mean, width = ma.options.rolling[s],na.rm=T))})
-          print(paste('stats:',stat.names2[s]))
+          my.stats2[, s] <- apply(cur.prcp, 2, function(x) {
+            min(rollapply(data = x, FUN = mean, width = ma.options.rolling[s], na.rm = T))
+          })
+          print(paste("stats:", stat.names2[s]))
         }
         colnames(my.stats2) <- stat.names2
         return(my.stats2)
       })
       my.stats2 <- unlist(stat.list2)
-      dim(my.stats2) <- c(n.sites,n.stats,d)    
+      dim(my.stats2) <- c(n.sites, n.stats, d)
       dimnames(my.stats2)[[2]] <- stat.names2
       return(my.stats2)
     }
-    
+
     n.dig <- 5
-    #individual site diagnostics
+    # individual site diagnostics
     nyears <- 10
-    stat.names2 <- paste0(seq(1,nyears),'.year')
-    stat.names22 <- paste0(seq(1,nyears),'-yr')
+    stat.names2 <- paste0(seq(1, nyears), ".year")
+    stat.names22 <- paste0(seq(1, nyears), "-yr")
     obs.diagnostics.min <- prcp.min.extreme.diagnostics(list(mean.wy.prcp.site))
-    obs.diagnostics.min.extreme <- as.matrix(obs.diagnostics.min[,,1])
-    obs.stats.min <- round(obs.diagnostics.min.extreme,digits = n.dig)
-    
+    obs.diagnostics.min.extreme <- as.matrix(obs.diagnostics.min[, , 1])
+    obs.stats.min <- round(obs.diagnostics.min.extreme, digits = n.dig)
+
     sim.diagnostics.min <- prcp.min.extreme.diagnostics(list(mean.wy.prcp.site.sim))
-    sim.diagnostics.min.extreme <- as.matrix(sim.diagnostics.min[,,1])
-    
+    sim.diagnostics.min.extreme <- as.matrix(sim.diagnostics.min[, , 1])
+
     n.yr.obs.diagnostics.min.extreme.all <- obs.diagnostics.min.extreme
     n.yr.sim.diagnostics.min.all <- sim.diagnostics.min.extreme
-    
-    min.obs.sim <- min(c(n.yr.obs.diagnostics.min.extreme.all,n.yr.sim.diagnostics.min.all))
-    max.obs.sim <- max(c(n.yr.obs.diagnostics.min.extreme.all,n.yr.sim.diagnostics.min.all))
+
+    min.obs.sim <- min(c(n.yr.obs.diagnostics.min.extreme.all, n.yr.sim.diagnostics.min.all))
+    max.obs.sim <- max(c(n.yr.obs.diagnostics.min.extreme.all, n.yr.sim.diagnostics.min.all))
     plot(n.yr.sim.diagnostics.min.all,
-         n.yr.obs.diagnostics.min.extreme.all,
-         main='Worst Droughts', font.main = 1,
-         cex.axis=3,cex.lab=3.5,cex.main=4,
-         font.main=1,cex.sub=1.15,
-         frame=F,
-         xlab='',cex=6,xlim=c(min.obs.sim,
-                              max.obs.sim),
-         ylim=c(min.obs.sim,
-                max.obs.sim),
-         ylab='',col=seq(1,nyears),pch=seq(1,nyears))
-    abline(h=n.yr.obs.diagnostics.min.extreme.all,
-           lty=2,col=alpha(seq(1,nyears),0.25))
-    abline(v=n.yr.sim.diagnostics.min.all,
-           lty=2,col=alpha(seq(1,nyears),0.25))
-    abline(a=0,b=1, col='gray75',lwd=1.5, lty=2)
-    mtext(paste0(label2),1,col='gray30',line=3.5, cex=1.75)
-    mtext(paste0(label1),2,col='red',line=3.5, cex=1.75)
-    legend("bottomright", legend=stat.names22,pch=seq(1,nyears),
-           cex=2.5,
-           col=seq(1,nyears),title ='WY Total',
-           horiz = FALSE,inset=c(0,0.02),ncol=2)
-    #mtext(paste0('worst droughts'),4,cex=1.85,col='black')
-    mtext(paste0('at-basin'),4,adj=0.925, cex=2,col='purple')
-    
-    
+      n.yr.obs.diagnostics.min.extreme.all,
+      main = "Worst Droughts", font.main = 1,
+      cex.axis = 3, cex.lab = 3.5, cex.main = 4,
+      font.main = 1, cex.sub = 1.15,
+      frame = F,
+      xlab = "", cex = 6, xlim = c(
+        min.obs.sim,
+        max.obs.sim
+      ),
+      ylim = c(
+        min.obs.sim,
+        max.obs.sim
+      ),
+      ylab = "", col = seq(1, nyears), pch = seq(1, nyears)
+    )
+    abline(
+      h = n.yr.obs.diagnostics.min.extreme.all,
+      lty = 2, col = alpha(seq(1, nyears), 0.25)
+    )
+    abline(
+      v = n.yr.sim.diagnostics.min.all,
+      lty = 2, col = alpha(seq(1, nyears), 0.25)
+    )
+    abline(a = 0, b = 1, col = "gray75", lwd = 1.5, lty = 2)
+    mtext(paste0(label2), 1, col = "gray30", line = 3.5, cex = 1.75)
+    mtext(paste0(label1), 2, col = "red", line = 3.5, cex = 1.75)
+    legend("bottomright",
+      legend = stat.names22, pch = seq(1, nyears),
+      cex = 2.5,
+      col = seq(1, nyears), title = "WY Total",
+      horiz = FALSE, inset = c(0, 0.02), ncol = 2
+    )
+    # mtext(paste0('worst droughts'),4,cex=1.85,col='black')
+    mtext(paste0("at-basin"), 4, adj = 0.925, cex = 2, col = "purple")
+
+
     # (b)
     #----------------------------------------- #
     ## -- dry spells -- ##
     #----------------------------------------- #
-    spells.labels <- c('mean.wet.spell','max.wet.spell',
-                       'mean.dry.spell','max.dry.spell')
-    fct.spell.stats <- function(prcp.file){
-      prcp.thresh <- 0    #trace precipitation threshold (0 inches)
-      apply(prcp.file,2,function(x) {
+    spells.labels <- c(
+      "mean.wet.spell", "max.wet.spell",
+      "mean.dry.spell", "max.dry.spell"
+    )
+    fct.spell.stats <- function(prcp.file) {
+      prcp.thresh <- 0 # trace precipitation threshold (0 inches)
+      apply(prcp.file, 2, function(x) {
         y <- x[!is.na(x)]
         nn <- length(y)
         wet.dry <- y
-        wet.dry[wet.dry<=prcp.thresh] <- 0
-        wet.dry[wet.dry>prcp.thresh] <- 1
-        first.of.run <- c(1,which(diff(wet.dry)!=0) + 1)
-        last.of.run <- c(which(diff(wet.dry)!=0),nn)
-        run.length <- last.of.run-first.of.run + 1
+        wet.dry[wet.dry <= prcp.thresh] <- 0
+        wet.dry[wet.dry > prcp.thresh] <- 1
+        first.of.run <- c(1, which(diff(wet.dry) != 0) + 1)
+        last.of.run <- c(which(diff(wet.dry) != 0), nn)
+        run.length <- last.of.run - first.of.run + 1
         run.type <- wet.dry[first.of.run]
-        wet.dry.runs <- data.frame('type'=run.type,'first'=first.of.run,'last'=last.of.run,'length'=run.length)
+        wet.dry.runs <- data.frame("type" = run.type, "first" = first.of.run, "last" = last.of.run, "length" = run.length)
         result <- c(
-          mean(wet.dry.runs$length[wet.dry.runs$type==1]),
-          max(wet.dry.runs$length[wet.dry.runs$type==1]),
-          mean(wet.dry.runs$length[wet.dry.runs$type==0]),
-          max(wet.dry.runs$length[wet.dry.runs$type==0])
+          mean(wet.dry.runs$length[wet.dry.runs$type == 1]),
+          max(wet.dry.runs$length[wet.dry.runs$type == 1]),
+          mean(wet.dry.runs$length[wet.dry.runs$type == 0]),
+          max(wet.dry.runs$length[wet.dry.runs$type == 0])
         )
         return(result)
       })
     }
-    my.sim.col <- c('black')
-    my.obs.col <- c('red')
+    my.sim.col <- c("black")
+    my.obs.col <- c("red")
     obs.spell.stats <- fct.spell.stats(prcp.site.data)
     sim.spell.stats <- fct.spell.stats(prcp.site.data.sim)
-    x1 <- obs.spell.stats[3,]
-    x2 <- sim.spell.stats[3,]
-    x11 <- obs.spell.stats[4,]
-    x22 <- sim.spell.stats[4,]
-    
-    min_max_xs <- base::range(c(x1,x2))
-    boxplot(x1,horizontal = T,main='',ylim=min_max_xs,
-            col=alpha(my.obs.col,.2),outline=T,whisklty = 1,
-            boxcol=my.obs.col,medcol=my.obs.col,
-            whiskcol=my.obs.col,staplecol=my.obs.col,outcol=my.obs.col,
-            boxwex=.35,xlab='Mean length (days)',
-            cex.axis=2.75,cex.lab=2.5,cex.main=4,font.main=1)
-    boxplot(x2,add=T,horizontal = T,ylim=min_max_xs,
-            col=alpha(my.sim.col,.2),outline=T,whisklty = 1,
-            boxcol=my.sim.col,medcol=my.sim.col,
-            whiskcol=my.sim.col,staplecol=my.sim.col,outcol=my.sim.col,
-            boxwex=.2,
-            cex.axis=2.75,cex.lab=2.5,cex.main=5,font.main=1)
-    text(median(c(x1,x2)),0.65,cex=2.75,col='blue',
-         paste0('max. Obs=',round(max(x11),1),
-                ',\nmax. Sim=',round(max(x22),1)))
-    mtext('Dry Spells',3,cex=2.5,line = 1)
-    legend("topleft", legend=c(label1,label2),
-           fill=c("red", alpha(my.sim.col,.5)),cex=2.5,
-           bty = "n",horiz = FALSE,
-           title='at-site',title.col = 'purple',title.cex = 3.5)
-    
+    x1 <- obs.spell.stats[3, ]
+    x2 <- sim.spell.stats[3, ]
+    x11 <- obs.spell.stats[4, ]
+    x22 <- sim.spell.stats[4, ]
+
+    min_max_xs <- base::range(c(x1, x2))
+    boxplot(x1,
+      horizontal = T, main = "", ylim = min_max_xs,
+      col = alpha(my.obs.col, .2), outline = T, whisklty = 1,
+      boxcol = my.obs.col, medcol = my.obs.col,
+      whiskcol = my.obs.col, staplecol = my.obs.col, outcol = my.obs.col,
+      boxwex = .35, xlab = "Mean length (days)",
+      cex.axis = 2.75, cex.lab = 2.5, cex.main = 4, font.main = 1
+    )
+    boxplot(x2,
+      add = T, horizontal = T, ylim = min_max_xs,
+      col = alpha(my.sim.col, .2), outline = T, whisklty = 1,
+      boxcol = my.sim.col, medcol = my.sim.col,
+      whiskcol = my.sim.col, staplecol = my.sim.col, outcol = my.sim.col,
+      boxwex = .2,
+      cex.axis = 2.75, cex.lab = 2.5, cex.main = 5, font.main = 1
+    )
+    text(median(c(x1, x2)), 0.65,
+      cex = 2.75, col = "blue",
+      paste0(
+        "max. Obs=", round(max(x11), 1),
+        ",\nmax. Sim=", round(max(x22), 1)
+      )
+    )
+    mtext("Dry Spells", 3, cex = 2.5, line = 1)
+    legend("topleft",
+      legend = c(label1, label2),
+      fill = c("red", alpha(my.sim.col, .5)), cex = 2.5,
+      bty = "n", horiz = FALSE,
+      title = "at-site", title.col = "purple", title.cex = 3.5
+    )
+
     # (c...)
     #------------------------------------------------- #
     ## -- frequency of annual rolling mean drought -- ##
     #------------------------------------------------- #
-    drought.rol.mean <- c(1,2,3,5,10,20)
-    labs.metrics <- paste0(drought.rol.mean,'-yr')
-    annual.prcp <- apply(wy.data.obs,1,mean)
-    annual.prcp.sim <- apply(wy.data.sim,1,mean)
-    for (my.opt in 1:length(drought.rol.mean)){
-      obs.HRU <- rollmean(annual.prcp,drought.rol.mean[my.opt])
-      wgen.trace <- rollmean(annual.prcp.sim,drought.rol.mean[my.opt])
-      x_min_max <- c(min(obs.HRU,wgen.trace),max(obs.HRU,wgen.trace))
-      hgA <- hist(wgen.trace,plot = FALSE,breaks = 25)
-      hgB <- hist(obs.HRU,plot = FALSE,breaks = 25)
-      plot(hgA, col = alpha('gray',0.4),lty="blank",
-           main=paste0(labs.metrics[my.opt]),font.main = 1,
-           cex.axis=2.25,cex.lab=2.5,cex.main=4,
-           xlab='Precipitation',xlim=x_min_max,
-           ylab='# WYs') # Plot 1st histogram using a transparent color
-      plot(hgB, col = alpha('red',0.4), add = TRUE,lty="blank") # Add 2nd histogram using different color
-      abline(v=median(wgen.trace),
-             col='black',lwd=2,lty=1)
-      abline(v=median(obs.HRU),
-             col='red',lwd=3,lty=1)
-      abline(v=min(wgen.trace),
-             col='black',lwd=1.5,lty=2)
-      abline(v=min(obs.HRU),
-             col='red',lwd=2,lty=2)
-      abline(v=max(wgen.trace),
-             col='black',lwd=1.5,lty=2)
-      abline(v=max(obs.HRU),
-             col='red',lwd=2,lty=2)
-      if (my.opt==3){
+    drought.rol.mean <- c(1, 2, 3, 5, 10, 20)
+    labs.metrics <- paste0(drought.rol.mean, "-yr")
+    annual.prcp <- apply(wy.data.obs, 1, mean)
+    annual.prcp.sim <- apply(wy.data.sim, 1, mean)
+    for (my.opt in 1:length(drought.rol.mean)) {
+      obs.HRU <- rollmean(annual.prcp, drought.rol.mean[my.opt])
+      wgen.trace <- rollmean(annual.prcp.sim, drought.rol.mean[my.opt])
+      x_min_max <- c(min(obs.HRU, wgen.trace), max(obs.HRU, wgen.trace))
+      hgA <- hist(wgen.trace, plot = FALSE, breaks = 25)
+      hgB <- hist(obs.HRU, plot = FALSE, breaks = 25)
+      plot(hgA,
+        col = alpha("gray", 0.4), lty = "blank",
+        main = paste0(labs.metrics[my.opt]), font.main = 1,
+        cex.axis = 2.25, cex.lab = 2.5, cex.main = 4,
+        xlab = "Precipitation", xlim = x_min_max,
+        ylab = "# WYs"
+      ) # Plot 1st histogram using a transparent color
+      plot(hgB, col = alpha("red", 0.4), add = TRUE, lty = "blank") # Add 2nd histogram using different color
+      abline(
+        v = median(wgen.trace),
+        col = "black", lwd = 2, lty = 1
+      )
+      abline(
+        v = median(obs.HRU),
+        col = "red", lwd = 3, lty = 1
+      )
+      abline(
+        v = min(wgen.trace),
+        col = "black", lwd = 1.5, lty = 2
+      )
+      abline(
+        v = min(obs.HRU),
+        col = "red", lwd = 2, lty = 2
+      )
+      abline(
+        v = max(wgen.trace),
+        col = "black", lwd = 1.5, lty = 2
+      )
+      abline(
+        v = max(obs.HRU),
+        col = "red", lwd = 2, lty = 2
+      )
+      if (my.opt == 3) {
         legend("top",
-               legend=c('Sim [min,median,max]','Obs [min,median,max]'),
-               col=c('gray','red'),
-               cex=2.5,
-               fill=c('gray','red'),
-               border = c(NA,NA),
-               horiz = FALSE,inset=0.01)
-        mtext(paste0('at-basin'),4,adj=0.925, cex=2,col='purple')
+          legend = c("Sim [min,median,max]", "Obs [min,median,max]"),
+          col = c("gray", "red"),
+          cex = 2.5,
+          fill = c("gray", "red"),
+          border = c(NA, NA),
+          horiz = FALSE, inset = 0.01
+        )
+        mtext(paste0("at-basin"), 4, adj = 0.925, cex = 2, col = "purple")
       }
     }
-    
+
     dev.off()
   }
-  
-  print(paste0("-->> figures were saved at: ", './Figures/'))
-  
+
+  print(paste0(">>> DONE >>> Scenario: ", scenario,  " . Figures were saved at: ", dir.to.figures))
+
   # The end #
 }
+

--- a/Programs/functions/execute.simulations.R
+++ b/Programs/functions/execute.simulations.R
@@ -1,7 +1,9 @@
 execute.simulations <- function(parallel = FALSE, number_of_cores = NULL) {
   
   ######### Precipitation/Temperature Inputs #########
-  # location of obs weather data (RData format): weather data (e.g., precip and temp) as matrices (time x lat|lon: t-by-number of grids); dates vector for time; basin average precip (see the example meteohydro file)
+  # location of obs weather data (RData format): 
+  # weather data (e.g., precip and temp) as matrices (time x lat|lon: t-by-number of grids); 
+  # dates vector for time; basin average precip (see the example meteohydro file)
   load(path.to.processed.data.meteohydro) # load in weather data
   n.sites <- dim(prcp.site)[2] # Number of gridded points for precipitation
 
@@ -51,8 +53,7 @@ execute.simulations <- function(parallel = FALSE, number_of_cores = NULL) {
   thshd.prcp <- apply(prcp.site, 2, function(x) {
     quantile(x[x != 0], qq, na.rm = T)
   })
-  # The spearman correlation between the precipitation sites, used in the copula-based jitters
-  Sbasin <- cor(prcp.site, method = "spearman")
+
 
 
   ######### Gamma-GPD Distribution Parameters #########
@@ -123,8 +124,8 @@ execute.simulations <- function(parallel = FALSE, number_of_cores = NULL) {
     # The spearman correlation between the precipitation sites, used in the copula-based jitters
     Sbasin <- cor(prcp.site, method = "spearman")
     std.S.cond <- diag(rep(0.4, n.sites)) # lambda == 0.1,...,0.9 etc here (0.4)
-    SIGMA <- std.S.cond %*% Sbasin %*% t(std.S.cond)
-    S.cond <- SIGMA
+    # no need for an additional var (`SIGMA`) here 
+    S.cond <- std.S.cond %*% Sbasin %*% t(std.S.cond)
     
     jitter.samp <- vector("list", num.iter)
     samp.cf <- vector("list", num.iter)
@@ -133,6 +134,12 @@ execute.simulations <- function(parallel = FALSE, number_of_cores = NULL) {
       jitter.samp[[k]] <- rmvnorm(n, rep(0, n.sites), S.cond)
       samp.cf[[k]] <- rnorm(n, 0, 1)
     }
+    
+  } else {
+    
+    cat("\n - NO jittering applied\n")
+    jitter.samp <- NULL
+    samp.cf     <- NULL
     
   }
   
@@ -161,12 +168,12 @@ execute.simulations <- function(parallel = FALSE, number_of_cores = NULL) {
     future_lapply(seq_len(nrow(change.list)), function(change) {
       cur.tc.max <- change.list$tc.max[change]
       cur.tc.min <- change.list$tc.min[change]
-      cur.pccc <- change.list$pccc[change]
-      cur.pmuc <- change.list$pmuc[change]
-      cur.tc <- mean(cur.tc.max, cur.tc.min)
+      cur.pccc   <- change.list$pccc[change]
+      cur.pmuc   <- change.list$pmuc[change]
+      cur.tc     <- mean(cur.tc.max, cur.tc.min)
       
       # precipitation scaling (temperature change dependent)
-      perc.q <- (1 + cur.pccc)^cur.tc # scaling in the upper tail for each month of non-zero prcp
+      perc.q  <- (1 + cur.pccc)^cur.tc # scaling in the upper tail for each month of non-zero prcp
       perc.mu <- (1 + cur.pmuc) # scaling in the mean for each month of non-zero prcp
       
       # set the jitter
@@ -224,13 +231,12 @@ execute.simulations <- function(parallel = FALSE, number_of_cores = NULL) {
       start_time <- Sys.time()
       cur.tc.max <- change.list$tc.max[change]
       cur.tc.min <- change.list$tc.min[change]
-      cur.pccc <- change.list$pccc[change]
-      cur.pmuc <- change.list$pmuc[change]
-      
-      cur.tc <- mean(cur.tc.max, cur.tc.min)
+      cur.pccc   <- change.list$pccc[change]
+      cur.pmuc   <- change.list$pmuc[change]
+      cur.tc     <- mean(cur.tc.max, cur.tc.min)
       
       # precipitation scaling (temperature change dependent)
-      perc.q <- (1 + cur.pccc)^cur.tc # scaling in the upper tail for each month of non-zero prcp
+      perc.q  <- (1 + cur.pccc)^cur.tc # scaling in the upper tail for each month of non-zero prcp
       perc.mu <- (1 + cur.pmuc) # scaling in the mean for each month of non-zero prcp
       
       # set the jitter
@@ -288,7 +294,7 @@ execute.simulations <- function(parallel = FALSE, number_of_cores = NULL) {
   rm(resampled.date.sim, resampled.date.loc.sim, markov.chain.sim, mc.sim)
   invisible(gc())
   
-  ##################################################################################################
+  ###################################################################################
   print(paste0("--- done.  state= ", num.states, " --- ensemble member:", num.iter))
   print(paste0("------------------------------------------------------"))
   print(paste0("-->> simulated files were saved at= ", dir.to.sim.files))

--- a/Programs/functions/execute.simulations.R
+++ b/Programs/functions/execute.simulations.R
@@ -121,11 +121,14 @@ execute.simulations <- function(parallel = FALSE, number_of_cores = NULL) {
     cat("\n - Calculating jittering for perturbing the non-exceedance probabilities\n")
     set.seed(jitter_seed) # this ensures the copula-based jitters are always performed in the same way for each climate change
     
-    # The spearman correlation between the precipitation sites, used in the copula-based jitters
+    ### The spearman correlation between the precipitation sites, used in the copula-based jitters
     Sbasin <- cor(prcp.site, method = "spearman")
-    std.S.cond <- diag(rep(0.4, n.sites)) # lambda == 0.1,...,0.9 etc here (0.4)
-    # no need for an additional var (`SIGMA`) here 
-    S.cond <- std.S.cond %*% Sbasin %*% t(std.S.cond)
+    # std.S.cond <- diag(rep(0.4, n.sites)) # lambda == 0.1,..., 0.9 etc here (0.4)
+    # # no need for an additional var (`SIGMA`) here 
+    # S.cond <- std.S.cond %*% Sbasin %*% t(std.S.cond)
+    ### Because std.S.cond is a scalar diagonal matrix, we can simplify the calculation further
+    ### D.A.D^T = λI.A.λI = λ^2.A
+    S.cond <- 0.4^2 * Sbasin
     
     jitter.samp <- vector("list", num.iter)
     samp.cf <- vector("list", num.iter)

--- a/Programs/functions/execute.simulations.R
+++ b/Programs/functions/execute.simulations.R
@@ -290,7 +290,6 @@ execute.simulations <- function(parallel = FALSE, number_of_cores = NULL) {
   
   ##################################################################################################
   print(paste0("--- done.  state= ", num.states, " --- ensemble member:", num.iter))
-  gc()
   print(paste0("------------------------------------------------------"))
   print(paste0("-->> simulated files were saved at= ", dir.to.sim.files))
 }

--- a/Programs/functions/execute.simulations.R
+++ b/Programs/functions/execute.simulations.R
@@ -1,165 +1,298 @@
-execute.simulations <- function(){
+execute.simulations <- function(parallel = FALSE, number_of_cores = NULL) {
   
-  #########Precipitation/Temperature Inputs #########
-  
-  #location of obs weather data (RData format): weather data (e.g., precip and temp) as matrices (time x lat|lon: t-by-number of grids); dates vector for time; basin average precip (see the example meteohydro file)
-  load(path.to.processed.data.meteohydro) #load in weather data
+  ######### Precipitation/Temperature Inputs #########
+  # location of obs weather data (RData format): weather data (e.g., precip and temp) as matrices (time x lat|lon: t-by-number of grids); dates vector for time; basin average precip (see the example meteohydro file)
+  load(path.to.processed.data.meteohydro) # load in weather data
   n.sites <- dim(prcp.site)[2] # Number of gridded points for precipitation
-  
-  identical.dates.idx <- dates.weather%in%dates.synoptics
+
+  identical.dates.idx <- dates.weather %in% dates.synoptics
   dates.weather <- dates.weather[identical.dates.idx]
-  months.weather <- as.numeric(format(dates.weather,'%m'))
-  prcp.site <- prcp.site[identical.dates.idx,]
-  tmax.site <- tmax.site[identical.dates.idx,]
-  tmin.site <- tmin.site[identical.dates.idx,]
+  months.weather <- month(dates.weather)
+  prcp.site <- prcp.site[identical.dates.idx, ]
+  tmax.site <- tmax.site[identical.dates.idx, ]
+  tmin.site <- tmin.site[identical.dates.idx, ]
   prcp.basin <- prcp.basin[identical.dates.idx]
-  
-  identical.dates.idx <- dates.synoptics%in%dates.weather
+
+  identical.dates.idx <- dates.synoptics %in% dates.weather
   weather.state.assignments <- weather.state.assignments[identical.dates.idx]
-  
+
   # sanitary check if all days for that specific month and grid is zero === causing problems in gamma fit
   # this will be zero after implementing the quantile mapping, so there is no effect whatsoever
   {
-    indicators.month.sites <- array(NA,c(length(months),n.sites))
-    indicators.month.unit <- array(NA,length(months))
-    for (mo in months){
-      for (r in 1:n.sites){
-        indicators.month.sites[mo,r] <- sum(prcp.site[months.weather==mo,r]==0)/sum(months.weather==mo)
+    indicators.month.sites <- array(NA, c(length(months), n.sites))
+    indicators.month.unit <- array(NA, length(months))
+    for (mo in months) {
+      for (r in 1:n.sites) {
+        indicators.month.sites[mo, r] <- sum(prcp.site[months.weather == mo, r] == 0) / sum(months.weather == mo)
       }
-      indicators.month.unit[mo] <- sum(months.weather==mo)
+      indicators.month.unit[mo] <- sum(months.weather == mo)
     }
     required.daily.vals <- 2
-    low.sample.size <- min(1-required.daily.vals/indicators.month.unit)
-    if (sum(indicators.month.sites>=low.sample.size)>0){
-      mo.site <- which(indicators.month.sites>=low.sample.size,arr.ind = T)
-      for (mi in 1:dim(mo.site)[1]){
+    low.sample.size <- min(1 - required.daily.vals / indicators.month.unit)
+    if (sum(indicators.month.sites >= low.sample.size) > 0) {
+      mo.site <- which(indicators.month.sites >= low.sample.size, arr.ind = T)
+      for (mi in 1:dim(mo.site)[1]) {
         set.seed(100)
-        escaping.value <- runif(sum(months.weather==mo.site[mi,1]),min=0,max=0.01) # giving random small values in mm
-        prcp.site[months.weather==mo.site[mi,1],mo.site[mi,2]] <- escaping.value
+        escaping.value <- runif(sum(months.weather == mo.site[mi, 1]), min = 0, max = 0.01) # giving random small values in mm
+        prcp.site[months.weather == mo.site[mi, 1], mo.site[mi, 2]] <- escaping.value
       }
     }
-    
+
     # check if all days for that specific month and grid is negative === causing problems in gamma fittings
-    indicators.sites <- which(prcp.site<0,arr.ind=T)
-    if (dim(indicators.sites)[1]>0){
+    indicators.sites <- which(prcp.site < 0, arr.ind = T)
+    if (dim(indicators.sites)[1] > 0) {
       set.seed(1000)
-      escaping.value <- runif(dim(indicators.sites)[1],min=0,max=0.001) # giving random values between 0 and 0.001 mm
-      prcp.site[indicators.sites] <- round(escaping.value,4)
+      escaping.value <- runif(dim(indicators.sites)[1], min = 0, max = 0.001) # giving random values between 0 and 0.001 mm
+      prcp.site[indicators.sites] <- round(escaping.value, 4)
     }
   }
 
-  #extreme threshold (Gamma-GPD cutoff) for each site
-  thshd.prcp <- apply(prcp.site,2,function(x) {quantile(x[x!=0],qq,na.rm=T)})
-  #The spearman correlation between the precipitation sites, used in the copula-based jitters
-  Sbasin <- cor(prcp.site,method="spearman")
-  
-  
-  ######### Gamma-GPD Distribution Parameters #########
-  
-  #fit emission distributions to each site by month. sites along the columns, parameters for month down the rows
-  emission.fits.site <- fit.emission(prcp.site=prcp.site,
-                                     months=months,
-                                     months.weather=months.weather,
-                                     n.sites=n.sites,
-                                     thshd.prcp=thshd.prcp)
-  
-  
-  #how often is prcp under threshold by month and site
-  qq.month <- sapply(1:n.sites,function(i,x=prcp.site,m,mm) {
-    sapply(m,function(m) {
-      length(which(as.numeric(x[x[,i]!=0 & mm==m & !is.na(x[,i]),i])<=thshd.prcp[i]))/length(as.numeric(x[x[,i]!=0 & mm==m & !is.na(x[,i]),i]))
-    })},
-    m=months, mm=months.weather)
-  
-  #################################################
-  
-  ##########################Simulate model with perturbations#######################################
+  # extreme threshold (Gamma-GPD cutoff) for each site
+  thshd.prcp <- apply(prcp.site, 2, function(x) {
+    quantile(x[x != 0], qq, na.rm = T)
+  })
+  # The spearman correlation between the precipitation sites, used in the copula-based jitters
+  Sbasin <- cor(prcp.site, method = "spearman")
 
-  #run the daily weather generate num.iter times using the num.iter Markov chains
-  mc.sim <- resampled.date.sim <- resampled.date.loc.sim <- prcp.site.sim <- tmin.site.sim <- tmax.site.sim <-  list()
+
+  ######### Gamma-GPD Distribution Parameters #########
+
+  # fit emission distributions to each site by month. sites along the columns, parameters for month down the rows
+  emission.fits.site <- fit.emission(
+    prcp.site = prcp.site,
+    months = months,
+    months.weather = months.weather,
+    n.sites = n.sites,
+    thshd.prcp = thshd.prcp
+  )
+
+  # how often is prcp under threshold by month and site
+  qq.month <- sapply(1:n.sites, function(i, x = prcp.site, m, mm) {
+    sapply(m, function(m) {
+      length(which(as.numeric(x[x[, i] != 0 & mm == m & !is.na(x[, i]), i]) <= thshd.prcp[i])) / length(as.numeric(x[x[, i] != 0 & mm == m & !is.na(x[, i]), i]))
+    })
+  },
+  m = months, mm = months.weather
+  )
+
+  
+
+  ########################## Simulate model with perturbations#######################################
+
+  # run the daily weather generate num.iter times using the num.iter Markov chains
+  # mc.sim <- resampled.date.sim <- resampled.date.loc.sim <- prcp.site.sim <- tmin.site.sim <- tmax.site.sim <- list()
+  ### Set the size of the outputs
+  mc.sim <- vector("list", num.iter)
+  resampled.date.sim <- vector("list", num.iter)
+  resampled.date.loc.sim <- vector("list", num.iter)
+  prcp.site.sim <- tmax.site.sim <- tmin.site.sim <- vector("list", num.iter)
   start_time <- Sys.time()
   for (k in 1:num.iter) {
     my.itertime <- Sys.time()
-    my.sim <- wgen.simulator(weather.state.assignments=weather.state.assignments,mc.sim=markov.chain.sim[[k]],
-                             prcp.basin=prcp.basin,dates.weather=dates.weather,
-                             first.month=first.month,last.month=last.month,dates.sim=dates.sim,
-                             months=months,window.size=window.size,min.thresh=pr.trace)
-    print(paste(k,":", Sys.time()-my.itertime))
-    
-    #each of these is a list of length iter
+    my.sim <- wgen.simulator(
+      weather.state.assignments = weather.state.assignments, mc.sim = markov.chain.sim[[k]],
+      prcp.basin = prcp.basin, dates.weather = dates.weather,
+      first.month = first.month, last.month = last.month, dates.sim = dates.sim,
+      months = months, window.size = window.size, min.thresh = pr.trace
+    )
+    print(paste(k, ":", Sys.time() - my.itertime))
+
+    # each of these is a list of length iter
     mc.sim[[k]] <- my.sim[[1]]
     resampled.date.sim[[k]] <- my.sim[[2]]
     resampled.date.loc.sim[[k]] <- my.sim[[3]]
-    prcp.site.sim[[k]] <- prcp.site[resampled.date.loc.sim[[k]],]
-    tmin.site.sim[[k]] <- tmin.site[resampled.date.loc.sim[[k]],]
-    tmax.site.sim[[k]] <- tmax.site[resampled.date.loc.sim[[k]],]
+    prcp.site.sim[[k]] <- prcp.site[resampled.date.loc.sim[[k]], ]
+    tmin.site.sim[[k]] <- tmin.site[resampled.date.loc.sim[[k]], ]
+    tmax.site.sim[[k]] <- tmax.site[resampled.date.loc.sim[[k]], ]
   }
-  end_time <- Sys.time(); run.time.sim <- end_time - start_time
-  print(paste("SIMULATION started at:",start_time,", ended at:",end_time)); print(round(run.time.sim,2))
-  #remove for memory
+  end_time <- Sys.time()
+  run.time.sim <- end_time - start_time
+  print(paste("SIMULATION started at:", start_time, ", ended at:", end_time))
+  print(round(run.time.sim, 2))
+  # remove for memory
   rm(my.sim)
+  invisible(gc())
+
   
   
-  #once the simulations are created, we now apply post-process climate changes (and jitters)
-  for (change in 1:nrow(change.list)) {
-    start_time <- Sys.time()
-    cur.tc.max <- change.list$tc.max[change]
-    cur.tc.min <- change.list$tc.min[change]
-    cur.pccc <- change.list$pccc[change]
-    cur.pmuc <- change.list$pmuc[change]
+  jitter_seed <- 1L
+  if (to.jitter) {
+    cat("\n - Calculating jittering for perturbing the non-exceedance probabilities\n")
+    set.seed(jitter_seed) # this ensures the copula-based jitters are always performed in the same way for each climate change
     
-    cur.tc <- mean(cur.tc.max,cur.tc.min)
+    # The spearman correlation between the precipitation sites, used in the copula-based jitters
+    Sbasin <- cor(prcp.site, method = "spearman")
+    std.S.cond <- diag(rep(0.4, n.sites)) # lambda == 0.1,...,0.9 etc here (0.4)
+    SIGMA <- std.S.cond %*% Sbasin %*% t(std.S.cond)
+    S.cond <- SIGMA
     
-    #precipitation scaling (temperature change dependent)
-    perc.q <- (1 + cur.pccc)^cur.tc    #scaling in the upper tail for each month of non-zero prcp
-    perc.mu <- (1 + cur.pmuc)          #scaling in the mean for each month of non-zero prcp
-    
-    #set the jitter
-    cur.jitter <- to.jitter
-    
-    #perturb the climate from the simulations above (the longest procedure in this function is saving the output files)
-    set.seed(1)   #this ensures the copula-based jitterrs are always performed in the same way for each climate change
-    perturbed.sim <-  perturb.climate(prcp.site.sim=prcp.site.sim,
-                                      tmin.site.sim=tmin.site.sim,
-                                      tmax.site.sim=tmax.site.sim,
-                                      emission.fits.site=emission.fits.site,
-                                      months=months,dates.sim=dates.sim,n.sites=n.sites,
-                                      qq=qq,perc.mu=perc.mu,perc.q=perc.q,Sbasin=Sbasin,cur.jitter=cur.jitter,
-                                      cur.tc.min=cur.tc.min,cur.tc.max=cur.tc.max,
-                                      num.iter=num.iter,thshd.prcp=thshd.prcp,qq.month=qq.month)
-    set.seed(NULL)
-    prcp.site.sim.perturbed <- perturbed.sim[[1]]
-    tmin.site.sim.perturbed <- perturbed.sim[[2]]
-    tmax.site.sim.perturbed <- perturbed.sim[[3]]
-    
-    #remove for memory
-    rm(perturbed.sim)
-    end_time <- Sys.time(); run.time.qmap <- end_time - start_time
-    print(paste("QMAPPING started at:",start_time,", ended at:",end_time)); print(round(run.time.qmap,2))
-    
-    #how to name each file name to track perturbations in each set of simulations
-    file.suffix <- paste0(".tmax.",cur.tc.max,".tmin.",cur.tc.min,"_p.CC.scale.",cur.pccc,"_p.mu.scale.",cur.pmuc,"_num.year.",number.years.long,"_with.",num.iter)
-    
-    print(paste("|---start saving---|"))
-    write.output.large(dir.to.sim.files,
-                       prcp.site.sim=prcp.site.sim.perturbed,
-                       tmin.site.sim=tmin.site.sim.perturbed,
-                       tmax.site.sim=tmax.site.sim.perturbed,
-                       mc.sim=mc.sim,resampled.date.sim=resampled.date.sim,
-                       dates.sim=dates.sim,file.suffix=file.suffix)
-    print(paste("|---finished saving---|"))
+    jitter.samp <- vector("list", num.iter)
+    samp.cf <- vector("list", num.iter)
+    for (k in seq_len(num.iter)) {
+      n <- nrow(prcp.site.sim[[k]])
+      jitter.samp[[k]] <- rmvnorm(n, rep(0, n.sites), S.cond)
+      samp.cf[[k]] <- rnorm(n, 0, 1)
+    }
     
   }
   
-  #remove for memory
-  rm(resampled.date.sim,resampled.date.loc.sim,markov.chain.sim,mc.sim)
+  # calculate month sequence for the simulation period to use in subsequent functions
+  months.sim <- month(dates.sim)
+  n.sim <- length(dates.sim) # length of the simulation period
+  
+  # once the simulations are created, we now apply post-process climate changes (and jitters)
+  if (parallel) { # Parallelize the change.list loop
+    
+    cat("\n - Running climate perturbation in parallel mode\n")
+    
+    p_load(future.apply)
+    options(future.globals.maxSize = 3.0 * 16e9) # 16e9 = 1.0 GB; adjust if needed
+    # set number of parallel cores
+    if (number_of_cores) {
+      num_cores <- number_of_cores
+    } else {
+      num_cores <- 2
+    }
+    if (num_cores < 1) num_cores <- 1
+    if (num_cores > nrow(change.list)) num_cores <- nrow(change.list)
+    plan(multisession, workers = num_cores)
+    
+    start_time <- Sys.time()
+    future_lapply(seq_len(nrow(change.list)), function(change) {
+      cur.tc.max <- change.list$tc.max[change]
+      cur.tc.min <- change.list$tc.min[change]
+      cur.pccc <- change.list$pccc[change]
+      cur.pmuc <- change.list$pmuc[change]
+      cur.tc <- mean(cur.tc.max, cur.tc.min)
+      
+      # precipitation scaling (temperature change dependent)
+      perc.q <- (1 + cur.pccc)^cur.tc # scaling in the upper tail for each month of non-zero prcp
+      perc.mu <- (1 + cur.pmuc) # scaling in the mean for each month of non-zero prcp
+      
+      # set the jitter
+      cur.jitter <- to.jitter
+      
+      # No need to set.seed here; future_lapply with future.seed handles it
+      perturbed.sim <- perturb.climate(
+        prcp.site.sim = prcp.site.sim,
+        tmin.site.sim = tmin.site.sim,
+        tmax.site.sim = tmax.site.sim,
+        emission.fits.site = emission.fits.site,
+        months = months, months.sim = months.sim, n.sim = n.sim, n.sites = n.sites,
+        qq = qq, perc.mu = perc.mu, perc.q = perc.q, Sbasin = Sbasin,
+        cur.jitter = cur.jitter, cur.tc.min = cur.tc.min, cur.tc.max = cur.tc.max,
+        num.iter = num.iter, thshd.prcp = thshd.prcp, qq.month = qq.month,
+        jitter.samp = jitter.samp, samp.cf = samp.cf
+      )
+      
+      prcp.site.sim.perturbed <- perturbed.sim[[1]]
+      tmin.site.sim.perturbed <- perturbed.sim[[2]]
+      tmax.site.sim.perturbed <- perturbed.sim[[3]]
+      
+      # memory clean-up
+      rm(perturbed.sim)
+      invisible(gc())
+      
+      file.suffix <- paste0(
+        ".tmax.", cur.tc.max, ".tmin.", cur.tc.min,
+        "_p.CC.scale.", cur.pccc, "_p.mu.scale.", cur.pmuc,
+        "_num.year.", number.years.long, "_with.", num.iter
+      )
+      
+      write.output.large(
+        dir.to.sim.files,
+        prcp.site.sim = prcp.site.sim.perturbed,
+        tmin.site.sim = tmin.site.sim.perturbed,
+        tmax.site.sim = tmax.site.sim.perturbed,
+        mc.sim = mc.sim, resampled.date.sim = resampled.date.sim,
+        dates.sim = dates.sim, file.suffix = file.suffix
+      )
+      
+    }, future.seed = jitter_seed)
+    
+    end_time <- Sys.time()
+    run.time.qmap <- end_time - start_time
+    print(paste("Quantile Mapping & Saving started at:", start_time, ", ended at:", end_time))
+    print(round(run.time.qmap, 2))
+    
+    set.seed(NULL)
+    plan(sequential)
+    
+  } else {
+    
+    for (change in 1:nrow(change.list)) {
+      start_time <- Sys.time()
+      cur.tc.max <- change.list$tc.max[change]
+      cur.tc.min <- change.list$tc.min[change]
+      cur.pccc <- change.list$pccc[change]
+      cur.pmuc <- change.list$pmuc[change]
+      
+      cur.tc <- mean(cur.tc.max, cur.tc.min)
+      
+      # precipitation scaling (temperature change dependent)
+      perc.q <- (1 + cur.pccc)^cur.tc # scaling in the upper tail for each month of non-zero prcp
+      perc.mu <- (1 + cur.pmuc) # scaling in the mean for each month of non-zero prcp
+      
+      # set the jitter
+      cur.jitter <- to.jitter
+      
+      # perturb the climate from the simulations above (the longest procedure in this function is saving the output files)
+      set.seed(1) # this ensures the copula-based jitterrs are always performed in the same way for each climate change
+      perturbed.sim <- perturb.climate(
+        prcp.site.sim = prcp.site.sim,
+        tmin.site.sim = tmin.site.sim,
+        tmax.site.sim = tmax.site.sim,
+        emission.fits.site = emission.fits.site,
+        months = months, months.sim = months.sim, n.sim = n.sim, n.sites = n.sites,
+        qq = qq, perc.mu = perc.mu, perc.q = perc.q, Sbasin = Sbasin,
+        cur.jitter = cur.jitter, cur.tc.min = cur.tc.min, cur.tc.max = cur.tc.max,
+        num.iter = num.iter, thshd.prcp = thshd.prcp, qq.month = qq.month,
+        jitter.samp = jitter.samp, samp.cf = samp.cf
+      )
+      set.seed(NULL)
+      
+      prcp.site.sim.perturbed <- perturbed.sim[[1]]
+      tmin.site.sim.perturbed <- perturbed.sim[[2]]
+      tmax.site.sim.perturbed <- perturbed.sim[[3]]
+      
+      # remove for memory
+      rm(perturbed.sim)
+      invisible(gc())
+      end_time <- Sys.time()
+      run.time.qmap <- end_time - start_time
+      print(paste("QMAPPING started at:", start_time, ", ended at:", end_time))
+      print(round(run.time.qmap, 2))
+      
+      # how to name each file name to track perturbations in each set of simulations
+      file.suffix <- paste0(".tmax.", cur.tc.max, 
+                            ".tmin.", cur.tc.min, 
+                            "_p.CC.scale.", cur.pccc, 
+                            "_p.mu.scale.", cur.pmuc, 
+                            "_num.year.", number.years.long, 
+                            "_with.", num.iter)
+      
+      print(paste("|---start saving---|"))
+      write.output.large(dir.to.sim.files,
+                         prcp.site.sim = prcp.site.sim.perturbed,
+                         tmin.site.sim = tmin.site.sim.perturbed,
+                         tmax.site.sim = tmax.site.sim.perturbed,
+                         mc.sim = mc.sim, resampled.date.sim = resampled.date.sim,
+                         dates.sim = dates.sim, file.suffix = file.suffix
+      )
+      print(paste("|---finished saving---|"))
+    }
+    
+  }
+
+  # remove for memory
+  rm(resampled.date.sim, resampled.date.loc.sim, markov.chain.sim, mc.sim)
+  invisible(gc())
+  
   ##################################################################################################
-  print(paste0("--- done.  state= ", num.states," --- ensemble member:",num.iter))
+  print(paste0("--- done.  state= ", num.states, " --- ensemble member:", num.iter))
   gc()
   print(paste0("------------------------------------------------------"))
   print(paste0("-->> simulated files were saved at= ", dir.to.sim.files))
-  
-
 }
 # The End
 #####################################################################################

--- a/Programs/functions/perturb.climate.R
+++ b/Programs/functions/perturb.climate.R
@@ -1,57 +1,67 @@
-
 perturb.climate <- function(prcp.site.sim,
                             tmin.site.sim,
                             tmax.site.sim,
-                            emission.fits.site,months,dates.sim,n.sites,
-                            qq,perc.mu,perc.q,Sbasin,cur.jitter,cur.tc.min,cur.tc.max,num.iter,thshd.prcp,qq.month) {
+                            emission.fits.site, months, months.sim, n.sim, n.sites,
+                            qq, perc.mu, perc.q, Sbasin,
+                            cur.jitter, cur.tc.min, cur.tc.max, num.iter, thshd.prcp, qq.month,
+                            jitter.samp = NULL, samp.cf = NULL) {
+  # this function takes the simulated prcp, tmax, and tmin from the daily weather generator and perturbs the data to
+  # 1) impose thermodynamic climate changes
+  # 2) impose copula-based jitters
   
-  #this function takes the simulated prcp, tmax, and tmin from the daily weather generator and perturbs the data to 
-  #1) impose thermodynamic climate changes
-  #2) impose copula-based jitters
+  # Arguemnts:
+  # prcp.site.sim = a list of length num.iter, with each list element containing a matrix of simulated daily prcp (rows: days; cols: sites)
+  # tmax.site.sim = a list of length num.iter, with each list element containing a matrix of simulated daily tmax (rows: days; cols: sites)
+  # tmin.site.sim = a list of length num.iter, with each list element containing a matrix of simulated daily tmin (rows: days; cols: sites)
+  # emission.fits.site = a list of length 2 (gamma and gpd fits), with each list containing an array of dimension (n.parameters x n.months x n.sites) 
+  #                       that contains emission distribution parameters for each site and and month
+  # months = a vector of the calendar months included in each year
+  # months.sim = month sequence for the simulation period
+  # n.sim = length of the simulation period
+  # n.sites = the number of sites across the basin
+  # qq = quantile to anchor the CC-scaling
+  # perc.mu = percent change in the mean for each month of non-zero prcp for CC-scaling
+  # perc.q = percent change in the qqth quantile for each month of non-zero prcp for CC-scaling
+  # Sbasin = the spearman correlation matrix (n.site x nsite) between the precipitation sites
+  # cur.jitter = TRUE/FALSE indicating whether we randomly perturb the non-exceedance probabilities at each site conditional on the basin average value?
+  # cur.tc.min = a step change to apply to all tmin temperatures
+  # cur.tc.max = a step change to apply to all tmax temperatures
+  # num.iter = the number of iterations for the simulation
+  # thshd.prcp = the threshold used to separate gamma from GPD
+  # qq.month = the frequency prcp under threshold by month and site
   
-  #Arguemnts:
-  #prcp.site.sim = a list of length num.iter, with each list element containing a matrix of simulated daily prcp (rows: days; cols: sites)
-  #tmax.site.sim = a list of length num.iter, with each list element containing a matrix of simulated daily tmax (rows: days; cols: sites)
-  #tmin.site.sim = a list of length num.iter, with each list element containing a matrix of simulated daily tmin (rows: days; cols: sites)
-  #emission.fits.site = a list of length 2 (gamma and gpd fits), with each list containing an array of dimension (n.parameters x n.months x n.sites) that contains emission distribution parameters for each site and and month
-  #months = a vector of the calendar months included in each year
-  #dates.sim = a vector of dates over the simulation period
-  #n.sites = the number of sites across the basin
-  #qq = quantile to anchor the CC-scaling
-  #perc.mu = percent change in the mean for each month of non-zero prcp for CC-scaling
-  #perc.q = percent change in the qqth quantile for each month of non-zero prcp for CC-scaling
-  #Sbasin = the spearman correlation matrix (n.site x nsite) between the precipitation sites
-  #cur.jitter = TRUE/FALSE indicating whether we randomly perturb the non-exceedance probabilities at each site conditional on the basin average value?
-  #cur.tc.min = a step change to apply to all tmin temperatures
-  #cur.tc.max = a step change to apply to all tmax temperatures
-  #num.iter = the number of iterations for the simulation
-  #thshd.prcp = the threshold used to separate gamma from GPD
-  #qq.month = the frequency prcp under threshold by month and site
-  
-  #create time series of gamma parameters for both original and CC-scaled gamma distribution
-  emission.fit.old.new1 <- CC.scale(emission.fits.site=emission.fits.site,months=months,dates.sim=dates.sim,
-                                      n.sites=n.sites,perc.mu=perc.mu,perc.q=perc.q,thshd.prcp=thshd.prcp,qq.month=qq.month)
+  # create time series of gamma parameters for both original and CC-scaled gamma distribution
+  emission.fit.old.new1 <- CC.scale(
+    emission.fits.site = emission.fits.site, months = months, 
+    months.sim = months.sim, n.sim = n.sim, n.sites = n.sites, 
+    perc.mu = perc.mu, perc.q = perc.q, thshd.prcp = thshd.prcp, qq.month = qq.month
+  )
   emission.old1 <- emission.fit.old.new1[[1]]
   emission.new1 <- emission.fit.old.new1[[2]]
   emission.old2 <- emission.fits.site[[2]]
-  #loop through each of the iterations and impose the appropriate scaling change
-  for (j in 1:num.iter) {  
+  # loop through each of the iterations and impose the appropriate scaling change
+  for (j in seq_len(num.iter)) {
     my.systime <- Sys.time()
-    #perturb the simulated time series of precipitation at each site
-    prcp.site.sim[[j]] <- quantile.mapping(prcp.site=prcp.site.sim[[j]],
-                                           Sbasin=Sbasin,thshd.prcp=thshd.prcp,perc.q=perc.q,
-                                           emission.old1=emission.old1,
-                                           emission.old2=emission.old2,
-                                           emission.new1=emission.new1,
-                                           n.sites=n.sites,months=months,dates.sim=dates.sim,cur.jitter=cur.jitter)
+    # perturb the simulated time series of precipitation at each site
+    prcp.site.sim[[j]] <- quantile.mapping(
+      prcp.site = prcp.site.sim[[j]],
+      Sbasin = Sbasin, thshd.prcp = thshd.prcp, perc.q = perc.q,
+      emission.old1 = emission.old1,
+      emission.old2 = emission.old2,
+      emission.new1 = emission.new1,
+      n.sites = n.sites, months = months,
+      months.sim = months.sim, cur.jitter = cur.jitter,
+      jitter.samp = jitter.samp[[j]], samp.cf = samp.cf[[j]]
+    )
     
-    #Add in temperature trends
+    # Add in temperature trends
     tmin.site.sim[[j]] <- tmin.site.sim[[j]] + cur.tc.min
     tmax.site.sim[[j]] <- tmax.site.sim[[j]] + cur.tc.max
-    #dont let tmin exceed tmax - replace tmax with tmin if this situation occurs
+    # dont let tmin exceed tmax - replace tmax with tmin if this situation occurs
     tmax.site.sim[[j]][tmin.site.sim[[j]] > tmax.site.sim[[j]]] <- tmin.site.sim[[j]][tmin.site.sim[[j]] > tmax.site.sim[[j]]]
     
-    print(paste("Quant map",j,":", Sys.time()-my.systime))
+    print(paste("Quant map", j, ":", Sys.time() - my.systime))
   }
-  return(list(prcp.site.sim,tmin.site.sim,tmax.site.sim))
+  return(list(prcp.site.sim, tmin.site.sim, tmax.site.sim))
 }
+

--- a/Programs/functions/quantile.mapping.R
+++ b/Programs/functions/quantile.mapping.R
@@ -1,134 +1,161 @@
-quantile.mapping <- function(prcp.site,Sbasin,thshd.prcp,perc.q,emission.old1,emission.old2,emission.new1,n.sites,months,dates.sim,cur.jitter) {
+quantile.mapping <- function(prcp.site, Sbasin, thshd.prcp, perc.q,
+                             emission.old1, emission.old2, emission.new1,
+                             n.sites, months, months.sim, cur.jitter,
+                             jitter.samp = NULL, samp.cf = NULL) {
+  # this function takes simulated precipitation at n.sites sites, and then adjusts the values through quantile mapping.
+  # in the mapping "new" (i.e., adjusted) gamma distributions for each site are used (these could be CC-scaled from original).
+  # also, there is an option to adjust the non-exeedance probabilities using the conditional variance of the sites based on the basin average
   
-  #this function takes simulated precipitation at n.sites sites, and then adjusts the values through quantile mapping.
-  #in the mapping "new" (i.e., adjusted) gamma distributions for each site are used (these could be CC-scaled from original).
-  #also, there is an option to adjust the non-exeedance probabilities using the conditional variance of the sites based on the basin average
+  # Arguments:
+  # (1): gamma; (2): gpd
+  # prcp.site =  a matrix (n.sim x n.sites) of simulated prcp values for the sites
+  # Sbasin = the spearman correlation matrix (n.site x nsite) between the precipitation sites
+  # thshd.prcp = threshold for gpd fit
+  # perc.q = the percentage to scale the upper tail of the distributions
+  # emission.old1 = 'gamma', an (n.sim x n.sites x n.parameters) matrix containing time series of original emission parameters for each site
+  # emission.old2 = 'gpd', an (n.sim x n.sites x n.parameters) matrix containing time series of original emission parameters for each site
+  # emission.new1 = 'gamma', an (n.sim x n.sites x n.parameters) matrix containing time series of adjusted emission parameters for each site
+  # n.sites = the number of individual sites
+  # months = a vector of calendar months for the season
+  # months.sim = month sequence for the simulation period
+  # cur.jitter = TRUE/FALSE indicating whether to perturb the non-exceedance probabilities
   
-  #Arguments:
-  #(1): gamma; (2): gpd
-  #prcp.site =  a matrix (n.sim x n.sites) of simulated prcp values for the sites 
-  #Sbasin = the spearman correlation matrix (n.site x nsite) between the precipitation sites
-  #thshd.prcp = threshold for gpd fit
-  #perc.q = the percentage to scale the upper tail of the distributions
-  #emission.old1 = 'gamma', an (n.sim x n.sites x n.parameters) matrix containing time series of original emission parameters for each site
-  #emission.old2 = 'gpd', an (n.sim x n.sites x n.parameters) matrix containing time series of original emission parameters for each site
-  #emission.new1 = 'gamma', an (n.sim x n.sites x n.parameters) matrix containing time series of adjusted emission parameters for each site
-  #n.sites = the number of individual sites
-  #months = a vector of calendar months for the season
-  #dates.sim = a time series of the simulated dates
-  #cur.jitter = TRUE/FALSE indicating whether to perturb the non-exceedance probabilities
+  ### Move this calculation outside to avoid recalculation for every climate change scenario
+  # # create the conditional correlation matrix for the sites
+  # std.S.cond <- diag(rep(0.4, n.sites)) # lambda == 0.1,...,0.9 etc here (0.4)
+  # SIGMA <- std.S.cond %*% Sbasin %*% t(std.S.cond)
+  # S.cond <- SIGMA
+  #
+  # n <- dim(prcp.site)[1]
   
-  months.sim <- as.numeric(format(dates.sim,"%m")) # t-by-1
-  
-  #create the conditional correlation matrix for the sites
-  std.S.cond <- diag(rep(0.4,n.sites)) # lambda == 0.1,...,0.9 etc here (0.4)
-  SIGMA <- std.S.cond%*%Sbasin%*%t(std.S.cond)
-  S.cond <- SIGMA
-  
-  n <- dim(prcp.site)[1]
-  
-  idx1 <- sapply(1:n.sites,function(x,v){
-    which(prcp.site[,x]!=0 & !is.na(prcp.site[,x]) & prcp.site[,x]<v[x])
-  },v=thshd.prcp)
-  idx2 <- sapply(1:n.sites,function(x,v){
-    which(prcp.site[,x]!=0 & !is.na(prcp.site[,x]) & prcp.site[,x]>=v[x])
-  },v=thshd.prcp)
-  months.sim.1 <- sapply(1:n.sites,function(x) {months.sim[idx1[[x]]]
+  idx1 <- sapply(1:n.sites, function(x, v) {
+    which(prcp.site[, x] != 0 & !is.na(prcp.site[, x]) & prcp.site[, x] < v[x])
+  }, v = thshd.prcp)
+  idx2 <- sapply(1:n.sites, function(x, v) {
+    which(prcp.site[, x] != 0 & !is.na(prcp.site[, x]) & prcp.site[, x] >= v[x])
+  }, v = thshd.prcp)
+  months.sim.1 <- sapply(1:n.sites, function(x) {
+    months.sim[idx1[[x]]]
   })
-  months.sim.2 <- sapply(1:n.sites,function(x) {months.sim[idx2[[x]]]
+  months.sim.2 <- sapply(1:n.sites, function(x) {
+    months.sim[idx2[[x]]]
   })
   
-  #//(1) gamma:
-  #calculate the U's using old emission (1) distribution for precip less than threshold
-  prcp.site.u1 <- sapply(1:n.sites,function(x,z,m,mm) {
-    pgamma(prcp.site[idx1[[x]],x],'shape'=z[1,match(m[idx1[[x]]],mm),x],'rate'=z[2,match(m[idx1[[x]]],mm),x])
-  }, z=emission.old1,m=months.sim,mm=months
-  )
-
-  #replace any probability==1 (to avoid getting 'inf' instances in next 'sapply') with a very close value to 1.
-  check.probs.one <- sapply(1:n.sites,function(x) {sum(prcp.site.u1[[x]]==1)>0})
-  if (sum(check.probs.one==1)>0){
-    idx.ones <- lapply(prcp.site.u1,function(x){which(x==1)})
-    prcp.site.u1 <- sapply(1:n.sites,function(x) {
-      replace(prcp.site.u1[[x]],idx.ones[[x]],1-.Machine$double.eps)
+  # //(1) gamma:
+  # calculate the U's using old emission (1) distribution for precip less than threshold
+  prcp.site.u1 <- sapply(1:n.sites, function(x, z, m, mm) {
+    pgamma(prcp.site[idx1[[x]], x], "shape" = z[1, match(m[idx1[[x]]], mm), x], "rate" = z[2, match(m[idx1[[x]]], mm), x])
+  }, z = emission.old1, m = months.sim, mm = months)
+  
+  # replace any probability==1 (to avoid getting 'inf' instances in next 'sapply') with a very close value to 1.
+  check.probs.one <- sapply(1:n.sites, function(x) {
+    sum(prcp.site.u1[[x]] == 1) > 0
+  })
+  if (sum(check.probs.one == 1) > 0) {
+    idx.ones <- lapply(prcp.site.u1, function(x) {
+      which(x == 1)
+    })
+    prcp.site.u1 <- sapply(1:n.sites, function(x) {
+      replace(prcp.site.u1[[x]], idx.ones[[x]], 1 - .Machine$double.eps)
     })
   }
   
-  #transform new U's to new precipitation using new emission distributions
-  prcp.site.new1 <- sapply(1:n.sites,function(x,z,m,mm) {
-    qgamma(prcp.site.u1[[x]],'shape'=z[1,match(m[[x]],mm),x],'rate'=z[2,match(m[[x]],mm),x])
-  },z=emission.new1,m=months.sim.1,mm=months
-  )
-  #round to limit memory size
-  prcp.site.new1 <- sapply(1:n.sites,function(x) {round(prcp.site.new1[[x]],2)})
+  # transform new U's to new precipitation using new emission distributions
+  prcp.site.new1 <- sapply(1:n.sites, function(x, z, m, mm) {
+    qgamma(prcp.site.u1[[x]], "shape" = z[1, match(m[[x]], mm), x], "rate" = z[2, match(m[[x]], mm), x])
+  }, z = emission.new1, m = months.sim.1, mm = months)
+  # round to limit memory size
+  prcp.site.new1 <- sapply(1:n.sites, function(x) {
+    round(prcp.site.new1[[x]], 2)
+  })
   
   
-  #//(2) gpd:
-  #calculate the U's using old emission (2) distribution for precip greater than threshold
-  prcp.site.u2 <- sapply(1:n.sites,function(x,z) {
-    evmix::pgpd(prcp.site[idx2[[x]],x],'xi'=z[2,x],'sigmau'=z[1,x],'u'=thshd.prcp[x])
-  }, z=emission.old2)
+  # //(2) gpd:
+  # calculate the U's using old emission (2) distribution for precip greater than threshold
+  prcp.site.u2 <- sapply(1:n.sites, function(x, z) {
+    evmix::pgpd(prcp.site[idx2[[x]], x], "xi" = z[2, x], "sigmau" = z[1, x], "u" = thshd.prcp[x])
+  }, z = emission.old2)
   
   prcp.site.u2.new <- prcp.site.u2
-  if (cur.jitter) {   # if we want to perturb U's, jump into Z space to do the jittering :)
-    #then get Zs
-    prcp.site.z2 <- lapply(prcp.site.u2,function(x) {qnorm(x)})
-    #simulate new Zs
-    jitter.samp <- rmvnorm(n,rep(0,n.sites),S.cond)
-    jitter.samp2 <- sapply(1:n.sites,function(x) {jitter.samp[idx2[[x]],x]})
+  if (cur.jitter) { # if we want to perturb U's, jump into Z space to do the jittering :)
     
-    prcp.site.z2.proposed <- sapply(1:n.sites,function(x) {prcp.site.z2[[x]]+jitter.samp2[[x]]})
-
-    #transform new Z's to new U's
-    prcp.site.u2.proposed <- lapply(prcp.site.z2.proposed,function(x){pnorm(x)})
-
-    #accept proposed u with probability proportional to ratio of old and new exceedance ratios
-    set.seed(1)
-    samp.cf <- rnorm(n,0,1)
-    samp2.cf <- sapply(1:n.sites,function(x) {samp.cf[idx2[[x]]]})
-    coin.flip <- lapply(samp2.cf,function(x){pnorm(x)})
+    # then get Zs
+    prcp.site.z2 <- lapply(prcp.site.u2, function(x) {
+      qnorm(x)
+    })
+    ### simulate new Zs
+    ### move `jitter.samp` to the execute.simulation.R to to avoid recalculation
+    # jitter.samp <- rmvnorm(n, rep(0, n.sites), S.cond)
+    jitter.samp2 <- sapply(1:n.sites, function(x) {
+      jitter.samp[idx2[[x]], x]
+    })
     
-    prcp.site.u2.new <- sapply(1:n.sites,function(i,x,y,cf) {
+    prcp.site.z2.proposed <- sapply(1:n.sites, function(x) {
+      prcp.site.z2[[x]] + jitter.samp2[[x]]
+    })
+    
+    # transform new Z's to new U's
+    prcp.site.u2.proposed <- lapply(prcp.site.z2.proposed, function(x) {
+      pnorm(x)
+    })
+    
+    ### accept proposed u with probability proportional to ratio of old and new exceedance ratios
+    ### move `samp.cf` calculation to the execute.simulation.R to to avoid recalculation
+    # set.seed(1) 
+    # samp.cf <- rnorm(n, 0, 1)
+    samp2.cf <- sapply(1:n.sites, function(x) {
+      samp.cf[idx2[[x]]]
+    })
+    coin.flip <- lapply(samp2.cf, function(x) {
+      pnorm(x)
+    })
+    
+    prcp.site.u2.new <- sapply(1:n.sites, function(i, x, y, cf) {
       final <- y[[i]]
-
-      lower <- which(x[[i]]<y[[i]])
-      chance.of.replace <- x[[i]][lower]/y[[i]][lower]
-      replace <- cf[[i]][lower]<chance.of.replace
+      
+      lower <- which(x[[i]] < y[[i]])
+      chance.of.replace <- x[[i]][lower] / y[[i]][lower]
+      replace <- cf[[i]][lower] < chance.of.replace
       final[lower][replace] <- x[[i]][lower][replace]
-
-      higher <- which(x[[i]]>y[[i]])
-      chance.of.replace <- (1-x[[i]][higher])/(1-y[[i]][higher])
-      replace <- cf[[i]][higher]<chance.of.replace
+      
+      higher <- which(x[[i]] > y[[i]])
+      chance.of.replace <- (1 - x[[i]][higher]) / (1 - y[[i]][higher])
+      replace <- cf[[i]][higher] < chance.of.replace
       final[higher][replace] <- x[[i]][higher][replace]
-
+      
       return(final)
-    },x=prcp.site.u2.proposed,y=prcp.site.u2,cf=coin.flip)
+    }, x = prcp.site.u2.proposed, y = prcp.site.u2, cf = coin.flip)
   }
   
-  #replace any probability==1 (to avoid getting 'inf' instances in next 'sapply') with a very close value to 1.
-  check.probs.one <- sapply(1:n.sites,function(x) {sum(prcp.site.u2.new[[x]]==1)>0})
-  if (sum(check.probs.one==1)>0){
-    idx.ones <- lapply(prcp.site.u2.new,function(x){which(x==1)})
-    prcp.site.u0.new <- sapply(1:n.sites,function(x) {
-      replace(prcp.site.u2.new[[x]],idx.ones[[x]],1-.Machine$double.eps)
+  # replace any probability==1 (to avoid getting 'inf' instances in next 'sapply') with a very close value to 1.
+  check.probs.one <- sapply(1:n.sites, function(x) {
+    sum(prcp.site.u2.new[[x]] == 1) > 0
+  })
+  if (sum(check.probs.one == 1) > 0) {
+    idx.ones <- lapply(prcp.site.u2.new, function(x) {
+      which(x == 1)
+    })
+    prcp.site.u0.new <- sapply(1:n.sites, function(x) {
+      replace(prcp.site.u2.new[[x]], idx.ones[[x]], 1 - .Machine$double.eps)
     })
     prcp.site.u2.new <- prcp.site.u0.new
   }
   
-  #transform new U's to new precipitation using old emission distributions then multiply the values by (1.07)^d.T
-  prcp.site.new2 <- sapply(1:n.sites,function(x,z) {
-    perc.q*evmix::qgpd(prcp.site.u2.new[[x]],'xi'=z[2,x],'sigmau'=z[1,x],'u'=thshd.prcp[x])
-  },z=emission.old2)
-  #round to limit memory size
-  prcp.site.new2 <- sapply(1:n.sites,function(x) {round(prcp.site.new2[[x]],2)})
+  # transform new U's to new precipitation using old emission distributions then multiply the values by (1.07)^d.T
+  prcp.site.new2 <- sapply(1:n.sites, function(x, z) {
+    perc.q * evmix::qgpd(prcp.site.u2.new[[x]], "xi" = z[2, x], "sigmau" = z[1, x], "u" = thshd.prcp[x])
+  }, z = emission.old2)
+  # round to limit memory size
+  prcp.site.new2 <- sapply(1:n.sites, function(x) {
+    round(prcp.site.new2[[x]], 2)
+  })
   
-  
-  #// place the estimated precip back to the original time-series based on their indexes
+  # // place the estimated precip back to the original time-series based on their indexes
   prcp.site.new <- prcp.site
-  for(i in 1:n.sites){
-    prcp.site.new[idx1[[i]],i] <- prcp.site.new1[[i]]
-    prcp.site.new[idx2[[i]],i] <- prcp.site.new2[[i]]
+  for (i in 1:n.sites) {
+    prcp.site.new[idx1[[i]], i] <- prcp.site.new1[[i]]
+    prcp.site.new[idx2[[i]], i] <- prcp.site.new2[[i]]
   }
-  return(prcp.site.new)
   
+  return(prcp.site.new)
 }

--- a/Programs/functions/quantile.mapping.R
+++ b/Programs/functions/quantile.mapping.R
@@ -48,10 +48,10 @@ quantile.mapping <- function(prcp.site, Sbasin, thshd.prcp, perc.q,
   }, z = emission.old1, m = months.sim, mm = months)
   
   # replace any probability==1 (to avoid getting 'inf' instances in next 'sapply') with a very close value to 1.
-  check.probs.one <- sapply(1:n.sites, function(x) {
+  check.probs.one.u1 <- sapply(1:n.sites, function(x) {
     sum(prcp.site.u1[[x]] == 1) > 0
   })
-  if (sum(check.probs.one == 1) > 0) {
+  if (sum(check.probs.one.u1 == 1) > 0) {
     idx.ones <- lapply(prcp.site.u1, function(x) {
       which(x == 1)
     })
@@ -64,10 +64,10 @@ quantile.mapping <- function(prcp.site, Sbasin, thshd.prcp, perc.q,
   prcp.site.new1 <- sapply(1:n.sites, function(x, z, m, mm) {
     qgamma(prcp.site.u1[[x]], "shape" = z[1, match(m[[x]], mm), x], "rate" = z[2, match(m[[x]], mm), x])
   }, z = emission.new1, m = months.sim.1, mm = months)
-  # round to limit memory size
-  prcp.site.new1 <- sapply(1:n.sites, function(x) {
-    round(prcp.site.new1[[x]], 2)
-  })
+  # # round to limit memory size
+  # prcp.site.new1 <- sapply(1:n.sites, function(x) {
+  #   round(prcp.site.new1[[x]], 2)
+  # })
   
   
   # //(2) gpd:
@@ -76,7 +76,7 @@ quantile.mapping <- function(prcp.site, Sbasin, thshd.prcp, perc.q,
     evmix::pgpd(prcp.site[idx2[[x]], x], "xi" = z[2, x], "sigmau" = z[1, x], "u" = thshd.prcp[x])
   }, z = emission.old2)
   
-  prcp.site.u2.new <- prcp.site.u2
+  
   if (cur.jitter) { # if we want to perturb U's, jump into Z space to do the jittering :)
     
     # then get Zs
@@ -125,37 +125,42 @@ quantile.mapping <- function(prcp.site, Sbasin, thshd.prcp, perc.q,
       
       return(final)
     }, x = prcp.site.u2.proposed, y = prcp.site.u2, cf = coin.flip)
+  } else {
+    prcp.site.u2.new <- prcp.site.u2
   }
   
   # replace any probability==1 (to avoid getting 'inf' instances in next 'sapply') with a very close value to 1.
-  check.probs.one <- sapply(1:n.sites, function(x) {
+  check.probs.one.u2 <- sapply(1:n.sites, function(x) {
     sum(prcp.site.u2.new[[x]] == 1) > 0
   })
-  if (sum(check.probs.one == 1) > 0) {
+  if (sum(check.probs.one.u2 == 1) > 0) {
     idx.ones <- lapply(prcp.site.u2.new, function(x) {
       which(x == 1)
     })
-    prcp.site.u0.new <- sapply(1:n.sites, function(x) {
+    prcp.site.u2.new <- sapply(1:n.sites, function(x) {
       replace(prcp.site.u2.new[[x]], idx.ones[[x]], 1 - .Machine$double.eps)
     })
-    prcp.site.u2.new <- prcp.site.u0.new
+    # prcp.site.u2.new <- prcp.site.u0.new
   }
   
   # transform new U's to new precipitation using old emission distributions then multiply the values by (1.07)^d.T
   prcp.site.new2 <- sapply(1:n.sites, function(x, z) {
     perc.q * evmix::qgpd(prcp.site.u2.new[[x]], "xi" = z[2, x], "sigmau" = z[1, x], "u" = thshd.prcp[x])
   }, z = emission.old2)
-  # round to limit memory size
-  prcp.site.new2 <- sapply(1:n.sites, function(x) {
-    round(prcp.site.new2[[x]], 2)
-  })
+  # # round to limit memory size
+  # prcp.site.new2 <- sapply(1:n.sites, function(x) {
+  #   round(prcp.site.new2[[x]], 2)
+  # })
   
-  # // place the estimated precip back to the original time-series based on their indexes
-  prcp.site.new <- prcp.site
+  # // place the estimated precip back to the original time-series based on their indicies
+  # prcp.site.new <- prcp.site
+  prcp.site.new <- matrix(0, nrow = nrow(prcp.site), ncol = ncol(prcp.site))
   for (i in 1:n.sites) {
     prcp.site.new[idx1[[i]], i] <- prcp.site.new1[[i]]
     prcp.site.new[idx2[[i]], i] <- prcp.site.new2[[i]]
   }
+  # Round only once 
+  prcp.site.new <- round(prcp.site.new, 2)
   
   return(prcp.site.new)
 }

--- a/Programs/run.stochastic.weather.generator.R
+++ b/Programs/run.stochastic.weather.generator.R
@@ -1,28 +1,36 @@
 
-rm(list=ls())
+# rm(list=ls())
 
-library(MASS) # Gamma fit
-library(evmix) # GPD fit
-library(eva) # GPD fit
-library(depmixS4) # HMMs/NHMMs fit
-library(markovchain) # HMMs/NHMMs fit
-library(rebmix) # split/WRs
-library(lpSolve) # lp optimization
-library(mvtnorm) # MVN
-library(lubridate) # dates
-library(tictoc) # run time
-library(moments) # computation
-library(abind) # computation
-#--------------------------------
-library(zoo) # (plot)
-library(fExtremes) # (plot)
-library(scales) # (plot)
-library(parallel) # (plot)
-library(proxy) # (plot)
-library(POT) # (plot) event-based computations
-library(extRemes) # (plot)
-library(ismev) # (plot)
-library(readxl) # output
+# Load required libraries -------------------------------------------------
+
+### Use pacman to automatically install missing libraries
+if (!require("pacman")) install.packages("pacman")
+library(pacman)
+
+p_load(MASS)        # Gamma fit
+p_load(lpSolve)     # lp optimization
+p_load(mvtnorm)     # MVN
+p_load(moments)     # computation
+p_load(abind)       # computation
+p_load(lubridate)   # dates
+p_load(depmixS4)    # HMMs/NHMMs fit
+p_load(markovchain) # HMMs/NHMMs fit
+p_load(rebmix)      # split/WRs
+p_load(evmix)       # GPD fit
+p_load(eva)         # GPD fit
+p_load(POT)         # (plot) event-based computations
+p_load(extRemes)    # (plot)
+p_load(ismev)       # (plot)
+p_load(fExtremes)   # (plot)
+p_load(parallel)    # (plot)
+p_load(zoo)         # (plot)
+p_load(proxy)       # (plot)
+p_load(scales)      # (plot)
+p_load(readxl)      # output
+
+start_time0 <- Sys.time()
+
+# Load config file --------------------------------------------------------
 
 source("./Programs/config.simulations.R") # config file
 
@@ -30,8 +38,9 @@ lst <- config.simulations() # call in configuration inputs
 for (i in 1:length(lst)) {assign(names(lst[i]), lst[[i]]) }; rm(lst)
 
 
-#*************************************
-#--- Weather Regimes Module ---#
+
+# Weather Regimes Module --------------------------------------------------
+
 #use provided WRs
 if (use.provided.WRs){
   final.NHMM.output <- readRDS('./Data/simulated.data.files/WRs.out/final.NHMM.non_param.output.rds')
@@ -52,30 +61,41 @@ if (use.provided.WRs){
 rm(final.NHMM.output) # for memory
 
 
-#*************************************
-#--- Weather Generation Module ---#
-execute.simulations()
-# done. #
+
+# Weather Generation Module -----------------------------------------------
+
+start_time1 <- Sys.time()
+execute.simulations(parallel = FALSE, number_of_cores = NULL)
+# execute.simulations(parallel = TRUE, number_of_cores = 2)
+Sys.time() - start_time1
+invisible(gc())
 
 
-# EXTRA #
+
+# EXTRA -------------------------------------------------------------------
+
 ### Below are auxiliary functions to do a list of tasks
-#*************************************
 # - create sample figures for selected scenario
 # - generate individual output files in tab or text delimited formats
 
 #this is the scenario (i.e., the row in ClimateChangeScenarios.csv) for which to make plots and write out the data as .csv files
 selected_scenario = 1
 
-#--- figures ---#
+## Figures -----------------------------------------------------------------
 # arguments are labels for x and y-axes
-start_time <- Sys.time()
+start_time2 <- Sys.time()
 create.figures.baselines.stacked(scenario = selected_scenario)
-Sys.time() - start_time
+Sys.time() - start_time2
 
+## Output csv files --------------------------------------------------------
 
-#--- outputs ---#
 # YYYY, MM, DD, P(mm), Tmax(C), Tmin(C) in .csv individual lat/lon file #
 # for simulated data #
+start_time3 <- Sys.time()
 create.delimited.outputs(scenario = selected_scenario)
+Sys.time() - start_time3
 
+end_time0 <- Sys.time() - start_time0
+end_time0
+
+print(paste("Total runtime:", round(end_time0, 2)))

--- a/Programs/run.stochastic.weather.generator.R
+++ b/Programs/run.stochastic.weather.generator.R
@@ -95,7 +95,10 @@ start_time3 <- Sys.time()
 create.delimited.outputs(scenario = selected_scenario)
 Sys.time() - start_time3
 
-end_time0 <- Sys.time() - start_time0
-end_time0
+end_time0 <- Sys.time()
+time_taken0 <- end_time0 - start_time0
 
-print(paste("Total runtime:", round(end_time0, 2)))
+print(paste("Starting time: ", start_time0))
+print(paste("Ending time: ", end_time0))
+print(paste("Total runtime: "))
+time_taken0


### PR DESCRIPTION
Hello Nasser,

I've worked on finding opportunities for performance improvement of several functions. Here is what I've changed so far. Could you please take a look to see if they can be added to the main repo? Thank you very much!

- `execute.simulations()` has parallel option that can be turned on;
- move `jitter.samp` and `samp.cf` out of `quantile.mapping()` to avoid recalculation for each climate change scenario;
- add a fallback option using `tryCatch` in `CC.scale()` in case `optim` fails;
- use `data.table::fwrite` to speed up `create.delimited.outputs()` function.